### PR TITLE
Add `pass_filenames` option for configuring hooks.

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -104,12 +104,18 @@ let
                     '';
                   default = [];
                 };
+              pass_filenames =
+                mkOption {
+                  type = types.bool;
+                  description = "Whether to pass filenames as arguments to the entry point.";
+                  default = true;
+                };
             };
           config =
             {
               raw =
                 {
-                  inherit (config) name entry language files types;
+                  inherit (config) name entry language files types pass_filenames;
                   id = name;
                   exclude = mergeExcludes config.excludes;
                 };


### PR DESCRIPTION
This allows hooks to be invoked without passing the filenames to it. This can be useful if a hook needs to be invoked once, rather than once per changed file.