### PR TITLE
Run hpack if Haskell/cabal/package.yaml files change

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -56,8 +56,9 @@ in
           name = "hpack";
           description =
             "hpack converts package definitions in the hpack format (package.yaml) to Cabal files.";
-          entry = "${tools.hpack}/bin/hpack";
-          files = "^package.yaml$";
+          entry = "${tools.hpack}/bin/hpack --force .";
+          files = "(\\.l?hs$)|(^[^/]+\\.cabal$)|(^package\\.yaml$)";
+          pass_filenames = false;
         };
       ormolu =
         {


### PR DESCRIPTION
This runs the hpack hook if there is a chance that the package.yaml or cabal files are not in sync. This includes if Haskell files have changed, as it can change the set of modules in the Cabal file.

Fixes #43 