### PR TITLE
lorriHook

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ unset SSL_CERT_FILE
 unset NIX_SSL_CERT_FILE
 
 # Install pre-commit hooks
-eval "$shellHook"
+eval "$lorriHook"
 ```
 
 # Hooks


### PR DESCRIPTION
As per unmerged https://github.com/target/lorri/pull/265:
erroring shellHooks make lorri fail.

At the very least the foolowing hook config (somwhere) calls an external tool (turns out `git`, in casu)
```
let
  nix-pre-commit-hooks = import (builtins.fetchTarball "https://github.com/cachix/pre-commit-hooks.nix/tarball/master");
  pkgs = import <nixpkgs> {};
in {
  pre-commit-check = nix-pre-commit-hooks.run {
    src = ./.;
    hooks = {
      shellcheck.enable = true;
      shfmt = {
        enable = true;
        name = "shfmt";
        description = "Format Shell files";
        entry = "${pkgs.shfmt}/bin/shfmt -w -l";
        types = ["shell"];
      };
      prettier = {
        enable = true;
        name = "prettier";
        description = "Format JS, HTML, CSS, GraphQL, Markdown & YAML files";
        entry = "${pkgs.nodePackages.prettier}/bin/prettier --write --list-different";
        types = [
            "css"
            "graphql"
            "html"
            "javascript"
            "json"
            "jsx"
            "less"
            "markdown"
            # "mdx"
            "scss"
            "ts"
            "tsx"
            "vue"
            "yaml"
        ];
      };
    };
  };
}
```
It looks like lorriHook might eventually get executed by lorri direnv. (https://github.com/target/lorri/issues/415#issuecomment-640309487)

But until then, `$shellHook` + pre-commit-nix breakes lorri under certain circumstances