### PR TITLE
Simplify options

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1,10 +1,10 @@
 { config, lib, pkgs, ... }:
 let
-  inherit (config.pre-commit) tools settings;
+  inherit (config) tools settings;
   inherit (lib) mkOption types;
 in
 {
-  options.pre-commit.settings =
+  options.settings =
     {
       ormolu =
         {
@@ -27,7 +27,7 @@ in
         };
     };
 
-  config.pre-commit.hooks =
+  config.hooks =
     {
       ansible-lint =
         {

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -237,15 +237,26 @@ in
           readOnly = true;
         };
 
+      src =
+        lib.mkOption {
+          description = ''
+            Root of the project. By default this will be filtered with the gitignoreSource
+            function later, unless rootSrc is specified.
+          '';
+          type = lib.types.path;
+        };
+
       rootSrc =
         mkOption {
           type = types.package;
           description =
             ''
               The source of the project to be checked.
+
+              This is used in the derivation that performs the check.
             '';
-          defaultText = literalExample ''gitignoreSource config.root'';
-          default = gitignoreSource config.root;
+          defaultText = literalExample ''gitignoreSource config.src'';
+          default = gitignoreSource config.src;
         };
 
       excludes =

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -16,7 +16,7 @@ let
 
   inherit (pkgs) runCommand writeText git;
 
-  cfg = config.pre-commit;
+  cfg = config;
 
   hookType =
     types.submodule (
@@ -171,7 +171,7 @@ let
     ;
 in
 {
-  options.pre-commit =
+  options =
     {
 
       package =
@@ -275,7 +275,7 @@ in
   config =
     {
 
-      pre-commit.rawConfig =
+      rawConfig =
         {
           repos =
             [
@@ -288,7 +288,7 @@ in
           exclude = mergeExcludes cfg.excludes;
         };
 
-      pre-commit.installationScript =
+      installationScript =
         ''
           export PATH=$PATH:${cfg.package}/bin
           if ! type -t git >/dev/null; then

--- a/nix/run.nix
+++ b/nix/run.nix
@@ -16,21 +16,10 @@ let
         [
           ../modules/all-modules.nix
           {
-            options =
-              {
-                root =
-                  lib.mkOption {
-                    description = "Internal option";
-                    default = src;
-                    internal = true;
-                    readOnly = true;
-                    type = lib.types.unspecified;
-                  };
-              };
             config =
               {
                 _module.args.pkgs = pkgs;
-                inherit hooks excludes settings;
+                inherit hooks excludes settings src;
                 tools = builtinStuff.tools // tools;
               };
           }

--- a/nix/run.nix
+++ b/nix/run.nix
@@ -30,18 +30,15 @@ let
             config =
               {
                 _module.args.pkgs = pkgs;
-                pre-commit =
-                  {
-                    inherit hooks excludes settings;
-                    tools = builtinStuff.tools // tools;
-                  };
+                inherit hooks excludes settings;
+                tools = builtinStuff.tools // tools;
               };
           }
         ];
     };
-  inherit (project.config.pre-commit) installationScript;
+  inherit (project.config) installationScript;
 
 in
-project.config.pre-commit.run // {
+project.config.run // {
   shellHook = installationScript;
 }


### PR DESCRIPTION
Some simplifications to align the modules with the run function.

This also paves the way to a new 'public' function to allow using pre-commit-hooks.nix not as a distribution of packages but a configuration system only. Such a function will help users (eg #55) who want to use only their own packages by avoiding "bad" defaults and improving performance. (Out of scope for now)
