### PR TITLE
nixpkgs-fmt: include ".ignore" file

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -110,7 +110,7 @@ in
           name = "nixpkgs-fmt";
           description = "Nix code prettifier.";
           entry = "${tools.nixpkgs-fmt}/bin/nixpkgs-fmt";
-          files = "\\.nix$";
+          files = "(\\.nix$)|(\\.ignore$)";
         };
       nix-linter =
         {


### PR DESCRIPTION
This changes the default of `nixpkgs.files` to include an `.ignore`
file which nixpkgs-fmt reads to register exclusions.

Without this change, the behavior between running nixpkgs-fmt inside and
outside of the pre-commit hook is not consistent.