### PR TITLE
Fix purty invocation

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -188,7 +188,7 @@ in
         {
           name = "purty";
           description = "Format purescript files";
-          entry = "${tools.purty}/bin/purty --write";
+          entry = "${tools.purty}/bin/purty";
           files = "\\.purs$";
         };
     };

--- a/nix/purty/default.nix
+++ b/nix/purty/default.nix
@@ -1,0 +1,8 @@
+{ writeScriptBin, purty }:
+
+writeScriptBin "purty" ''
+  #!/usr/bin/env bash
+  for f in "$@"; do
+    ${purty}/bin/purty $f --write
+  done
+''

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -28,6 +28,6 @@
   inherit (elmPackages) elm-format;
   inherit (haskellPackages) stylish-haskell brittany hpack;
   inherit (pythonPackages) yamllint;
-  inherit (nodePackages) purty;
+  purty = callPackage ./purty { purty = nodePackages.purty; };
   terraform-fmt = callPackage ./terraform-fmt { };
 }


### PR DESCRIPTION
**purty** only accepts a single file on the command line but
the hook passes all modified files instead. This commit adds
a wrapper script that uses tools.purty but goes over all files
in a loop instead (analogous to how this has been implemented for terraform)