### PR TITLE
Accept nixpkgs and system as arguments

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,4 @@
-let pkgs = import ./nix { }; in pkgs.packages
+let
+  pkgs = import ./nix { };
+in
+pkgs.packages

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,6 @@
 { sources ? import ./sources.nix
 , system ? builtins.currentSystem
+, nixpkgs ? sources.nixpkgs
 }:
 let
   overlay =
@@ -11,7 +12,7 @@ let
       packages = pkgs.callPackages ./packages.nix { };
     };
 in
-import sources.nixpkgs {
+import nixpkgs {
   overlays = [ overlay ];
   config = { };
   inherit system;


### PR DESCRIPTION
This allows passing in of `nixpkgs` and `system` attributes to
default.nix and nix/default.nix