### PR TITLE
Adds support for prettier

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -25,6 +25,16 @@ in
               default = [ ];
             };
         };
+      prettier =
+        {
+          binPath =
+            mkOption {
+              type = types.str;
+              description =
+                "Prettier binary path. E.g. if you want to use the prettier in node_modules, use ./node_modules/.bin/prettier";
+              default = "${tools.prettier}/bin/prettier";
+            };
+        };
     };
 
   config.hooks =
@@ -190,6 +200,13 @@ in
           description = "Format purescript files";
           entry = "${tools.purty}/bin/purty";
           files = "\\.purs$";
+        };
+      prettier =
+        {
+          name = "prettier";
+          description = "Opinionated multi-language code formatter";
+          entry = "${settings.prettier.binPath} --write --list-different --ignore-unknown";
+          types = [ "text" ];
         };
     };
 }

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -29,7 +29,7 @@ in
         {
           binPath =
             mkOption {
-              type = types.str;
+              type = types.path;
               description =
                 "Prettier binary path. E.g. if you want to use the prettier in node_modules, use ./node_modules/.bin/prettier";
               default = "${tools.prettier}/bin/prettier";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -28,7 +28,7 @@
   inherit (elmPackages) elm-format;
   inherit (haskellPackages) stylish-haskell brittany hpack;
   inherit (pythonPackages) yamllint;
+  inherit (nodePackages) prettier;
   purty = callPackage ./purty { purty = nodePackages.purty; };
-  prettier = callPackage ./prettier { prettier = nodePackages.prettier; };
   terraform-fmt = callPackage ./terraform-fmt { };
 }

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -29,5 +29,6 @@
   inherit (haskellPackages) stylish-haskell brittany hpack;
   inherit (pythonPackages) yamllint;
   purty = callPackage ./purty { purty = nodePackages.purty; };
+  prettier = callPackage ./prettier { prettier = nodePackages.prettier; };
   terraform-fmt = callPackage ./terraform-fmt { };
 }


### PR DESCRIPTION
Using the local prettier config works as follows:

```
pre-commit-check = nix-pre-commit-hooks.run {
  settings = { prettier = { binPath = ./node_modules/.bin/prettier; }; };
}
```