### PR TITLE
Try fixing cargo check

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -200,7 +200,7 @@ in
         {
           name = "cargo-check";
           description = "Check the cargo package for errors";
-          entry = "${tools.cargo}/bin/cargo check";
+          entry = "${tools.cargo}/bin/cargo check --frozen";
           files = "\\.rs$";
           pass_filenames = false;
         };


### PR DESCRIPTION
Try to fix #94
nix-build does not allow for http access to ensure reproducibility. Since I were using the pre-commit hooks inside a CI which uses nix-build this will not work. So maybe we need something like https://github.com/nmattia/naersk to handle a pure package cache.