### PR TITLE
Use `types_or` instead of `types` for shellcheck

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -153,6 +153,7 @@ in
         {
           name = "shellcheck";
           description = "Format shell files";
+          types = [ "shell" ];
           types_or =
             # based on `goodShells` in https://github.com/koalaman/shellcheck/blob/master/src/ShellCheck/Parser.hs
             [

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -153,7 +153,7 @@ in
         {
           name = "shellcheck";
           description = "Format shell files";
-          types =
+          types_or =
             # based on `goodShells` in https://github.com/koalaman/shellcheck/blob/master/src/ShellCheck/Parser.hs
             [
               "sh"

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -84,6 +84,15 @@ let
                   '';
                 default = [ "file" ];
               };
+            types_or =
+              mkOption {
+                type = types.listOf types.str;
+                description =
+                  ''
+                    List of file types to run on, where only a single type needs to match.
+                  '';
+                default = [ ];
+              };
             description =
               mkOption {
                 type = types.str;
@@ -113,7 +122,7 @@ let
           {
             raw =
               {
-                inherit (config) name entry language files types pass_filenames;
+                inherit (config) name entry language files types types_or pass_filenames;
                 id = name;
                 exclude = mergeExcludes config.excludes;
               };


### PR DESCRIPTION
Fixes #105
