### PR TITLE
Ensure shellcheck runs even against files with no shebang

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -179,6 +179,7 @@ in
               "bats"
               "dash"
               "ksh"
+              "shell"
             ];
           entry = "${tools.shellcheck}/bin/shellcheck";
         };


### PR DESCRIPTION
In some cases it makes sense to write shell files using shellcheck directives instead of shebangs, such as when the shebang is added by nix (like when using `writeShellScriptBin`).

This change allows those files to be picked up by shellcheck by default, since types_or and types are checked with an AND operator.
