### PR TITLE
Removing local and passing silence option for hpack

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -6,6 +6,15 @@ in
 {
   options.settings =
     {
+      hpack =
+        {
+          silent =
+            mkOption {
+              type = types.bool;
+              description = "Should generation should be silent";
+              default = false;
+            };
+        };
       ormolu =
         {
           defaultExtensions =
@@ -73,7 +82,7 @@ in
           name = "hpack";
           description =
             "hpack converts package definitions in the hpack format (package.yaml) to Cabal files.";
-          entry = "${tools.hpack-dir}/bin/hpack-dir";
+          entry = "${tools.hpack-dir}/bin/hpack-dir --${if settings.hpack.silent then "silent" else "verbose"}";
           files = "(\\.l?hs$)|(^[^/]+\\.cabal$)|(^package\\.yaml$)";
         };
       ormolu =

--- a/nix/hpack-dir/default.nix
+++ b/nix/hpack-dir/default.nix
@@ -1,15 +1,17 @@
 { writeScriptBin, hpack }:
 
 writeScriptBin "hpack-dir" ''#!/usr/bin/env bash
-  for arg in "$@"; do
+  if [ "$1" == "--silent" ]; then
+    flag=$1
+  fi
+  for arg in "''${@:2}"; do
     dirname "$arg"
   done \
     | sort \
     | uniq \
     | while read dir; do
-        local packageyaml="$dir/package.yaml"
-        if [ -f "$packageyaml" ]; then
-          ${hpack}/bin/hpack --force "$packageyaml"
+        if [ -f "$dir/package.yaml" ]; then
+          ${hpack}/bin/hpack --force $flag "$dir/package.yaml"
         fi
       done
 ''


### PR DESCRIPTION
`local` keyword was producing an error on some bash
versions, being used out of the function scope,
decided to remove it.