### PR TITLE
Remove deprecated warning about clippy bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,6 @@ eval "$shellHook"
 - [clippy](https://github.com/rust-lang/rust-clippy)
 - cargo-check: Runs `cargo check`
 
-*Warning*: running `clippy` after `cargo check` hides
-(https://github.com/rust-lang/rust-clippy/issues/4612) all clippy specific
-errors. Clippy subsumes `cargo check` so only one of these two checks should by
-used at the same time.
-
 ## Shell
 
 - [shellcheck](https://github.com/koalaman/shellcheck)


### PR DESCRIPTION
The `cargo check`/`cargo clippy` bug is not there anymore (the corresponding issue has been closed, now that the fix hit stable).