### PR TITLE
Add clang-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,17 @@ used at the same time.
 ## Other Formatters
 
 - [prettier](https://prettier.io)
+- [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
+
+You must configure which languages should be formatted by `clang_format` using
+`clang-format.types_or`. For example to check both C and C++ files:
+
+```nix
+clang-format = {
+  enable = true;
+  types_or = [ "c" "c++" ];
+};
+```
 
 ## Custom hooks
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -53,6 +53,13 @@ in
           entry = "${pkgs.python3Packages.black}/bin/black";
           types = [ "file" "python" ];
         };
+      clang-format =
+        {
+          name = "clang-format";
+          description = "Format your code using clang-format";
+          entry = "${tools.clang-tools}/bin/clang-format -style=file -i";
+          types = [ "file" ];
+        };
       brittany =
         {
           name = "brittany";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -23,10 +23,11 @@
 , nodePackages
 , hunspell
 , html-tidy
+, clang-tools
 }:
 
 {
-  inherit hlint shellcheck ormolu hindent cabal-fmt nixpkgs-fmt nixfmt nix-linter rustfmt clippy cargo html-tidy;
+  inherit hlint shellcheck ormolu hindent cabal-fmt nixpkgs-fmt nixfmt nix-linter rustfmt clippy cargo html-tidy clang-tools;
   inherit (elmPackages) elm-format elm-review elm-test;
   inherit (haskellPackages) stylish-haskell brittany hpack fourmolu;
   inherit (python39Packages) yamllint ansible-lint;


### PR DESCRIPTION
The languages to format should be provided through `clang-format.types_or`, for example to enable both C and C++ files:

```nix
clang-format = {
  enable = true;
  types_or = [ "c" "c++" ];
};
```