### PR TITLE
Update dependencies to fix aarch64-darwin update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1619345332,
-        "narHash": "sha256-qHnQkEp1uklKTpx3MvKtY6xzgcqXDsz5nLilbbuL+3A=",
+        "lastModified": 1631561581,
+        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "2ebf2558e5bf978c7fb8ea927dfaed8fefab2e28",
+        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1619531122,
-        "narHash": "sha256-ovm5bo6PkZzNKh2YGXbRKYIjega0EjiEP0YDwyeXEYU=",
+        "lastModified": 1634074534,
+        "narHash": "sha256-nrTVbYtKEmnpplMevoMGH543W/+plfG21fynO+h5UWA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bb80d578e8ad3cb5a607f468ac00cc546d0396dc",
+        "rev": "a7662ec778e3a1326bc7c0f167bdf27e7f9fe311",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1637014545,
+        "narHash": "sha256-26IZAc5yzlD9FlDT54io1oqG/bBoyka+FJk5guaX4x4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "bba5dcc8e0b20ab664967ad83d24d64cb64ec4f4",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1634074534,
-        "narHash": "sha256-nrTVbYtKEmnpplMevoMGH543W/+plfG21fynO+h5UWA=",
+        "lastModified": 1637592213,
+        "narHash": "sha256-mVw9iXmAK7NJX5pZKt4rFrQndcyIPBuqbeyBd24jbl4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a7662ec778e3a1326bc7c0f167bdf27e7f9fe311",
+        "rev": "ff8f08c372f38531472767a6e172cc62eec1c4ef",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
flake-utils added `aarch64-darwin` to default systems. This breaks any flake that is using flake-utils + pre-commit-hooks.nix. I simply ran `nix flake update` for this PR. I ran `nix flake check`, which worked, and I am going to dog food it in the project that was broken. I will update this PR once things appear to be stable on my end, but if the owner thinks this is safe, we can merge before.

relevant commit in flake utils: https://github.com/numtide/flake-utils/commit/997f7efcb746a9c140ce1f13c72263189225f482