### PR TITLE
Add isort

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ eval "$shellHook"
 ## Python
 
 - [black](https://github.com/psf/black)
+- [isort](https://github.com/PyCQA/isort)
 
 ## Rust
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -92,6 +92,13 @@ in
           entry = "${tools.hpack-dir}/bin/hpack-dir --${if settings.hpack.silent then "silent" else "verbose"}";
           files = "(\\.l?hs$)|(^[^/]+\\.cabal$)|(^package\\.yaml$)";
         };
+      isort =
+        {
+          name = "isort";
+          description = "A Python utility / library to sort imports.";
+          entry = "${pkgs.python3Packages.isort}/bin/isort";
+          types = [ "file" "python" ];
+        };
       ormolu =
         {
           name = "ormolu";


### PR DESCRIPTION
Adds an isort hook for python files

I based this on the hook for `black` which, unlike the other hooks, uses `pkgs` rather than `tools`. Is this correct?