### PR TITLE
Remove the individual tools from the overlay

### DIFF
--- a/nix/call-tools.nix
+++ b/nix/call-tools.nix
@@ -1,0 +1,6 @@
+pkgs:
+pkgs.lib.flip builtins.removeAttrs [ "override" "overrideDerivation" ]
+  (pkgs.callPackage ./tools.nix {
+    cabal-fmt = (pkgs.haskell.lib.enableSeparateBinOutput pkgs.haskellPackages.cabal-fmt).bin;
+    hindent = pkgs.haskell.lib.enableSeparateBinOutput pkgs.haskellPackages.hindent;
+  })

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -8,13 +8,10 @@ let
   overlay =
     self: pkgs:
     let
-      tools = pkgs.lib.filterAttrs (k: v: !(pkgs.lib.any (a: k == a) [ "override" "overrideDerivation" ])) (pkgs.callPackage ./tools.nix { });
+      tools = import ./call-tools.nix pkgs;
       run = pkgs.callPackage ./run.nix { inherit pkgs tools isFlakes gitignore-nix-src; };
     in
     {
-      inherit (pkgs) nixfmt niv ormolu nixpkgs-fmt nix-linter;
-      cabal-fmt = (pkgs.haskell.lib.enableSeparateBinOutput pkgs.haskellPackages.cabal-fmt).bin;
-      hindent = pkgs.haskell.lib.enableSeparateBinOutput pkgs.haskellPackages.hindent;
       inherit tools run;
       # Flake style attributes
       packages = tools // {


### PR DESCRIPTION
This removes the individual tools from the overlay. They didn't need to be in the overlay, and this is a step towards an overlay-free pre-commit-hooks.nix that can take advantage of flake-based evaluation caching.