### PR TITLE
Add cabalDefaultExtensions setting to ormolu

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -23,6 +23,12 @@ in
               description = "Haskell language extensions to enable";
               default = [ ];
             };
+          cabalDefaultExtensions =
+            mkOption {
+              type = types.bool;
+              description = "Use default-extensions from .cabal files";
+              default = false;
+            };
         };
       alejandra =
         {
@@ -131,9 +137,13 @@ in
           name = "ormolu";
           description = "Haskell code prettifier.";
           entry =
-            "${tools.ormolu}/bin/ormolu --mode inplace ${
-            lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) settings.ormolu.defaultExtensions)
-            }";
+            let
+              extensions =
+                lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) settings.ormolu.defaultExtensions);
+              cabalExtensions =
+                if settings.ormolu.cabalDefaultExtensions then "--cabal-default-extensions" else "";
+            in
+            "${tools.ormolu}/bin/ormolu --mode inplace ${extensions} ${cabalExtensions}";
           files = "\\.l?hs$";
         };
       fourmolu =

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -1,4 +1,5 @@
 { ansible-lint
+, haskell
 , haskellPackages
 , hlint
 , shellcheck
@@ -29,11 +30,12 @@
 }:
 
 {
-  inherit hlint shellcheck ormolu hindent cabal-fmt alejandra nixpkgs-fmt nixfmt nix-linter statix rustfmt clippy cargo html-tidy clang-tools;
+  inherit hlint shellcheck hindent cabal-fmt alejandra nixpkgs-fmt nixfmt nix-linter statix rustfmt clippy cargo html-tidy clang-tools;
   inherit (elmPackages) elm-format elm-review elm-test;
   inherit (haskellPackages) stylish-haskell brittany hpack fourmolu;
   inherit (python39Packages) yamllint ansible-lint;
   inherit (nodePackages) prettier;
+  ormolu = haskell.packages.ghc921.ormolu;
   purty = callPackage ./purty { purty = nodePackages.purty; };
   terraform-fmt = callPackage ./terraform-fmt { };
   hpack-dir = callPackage ./hpack-dir { hpack = haskellPackages.hpack; };


### PR DESCRIPTION
This adds a setting to use ormolu's `--cabal-default-extensions` flag to read extensions from .cabal files.

The version of ormolu used by pre-commit-hooks.nix was old and didn't have this flag, so I pointed ormolu at the `ghc921` variant instead (ormolu v0.4.0.0, I believe). The downside is that we'd now depend on two different GHC versions (`haskellPackages` and `haskell.packages.ghc921`), which may be undesirable.