### PR TITLE
Add support for manual only hooks

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -3,6 +3,7 @@ let
   inherit (lib)
     attrNames
     concatStringsSep
+    compare
     filterAttrs
     literalExample
     mapAttrsToList
@@ -172,8 +173,14 @@ let
       git config --global user.email "you@example.com"
       git config --global user.name "Your Name"
       git commit -m "init"
-      echo "Running: $ pre-commit run --all-files"
-      ${cfg.package}/bin/pre-commit run --all-files
+      if [[ ${toString (compare install_stages [ "manual" ])} -eq 0 ]]
+      then
+        echo "Running: $ pre-commit run --hook-stage manual --all-files"
+        ${cfg.package}/bin/pre-commit run --hook-stage manual --all-files
+      else
+        echo "Running: $ pre-commit run --all-files"
+        ${cfg.package}/bin/pre-commit run --all-files
+      fi
       exitcode=$?
       git --no-pager diff --color
       touch $out


### PR DESCRIPTION
When hooks are configured for only the "manual" stage, they can only be run by specifying the stage using `pre-commit run --hook-stages manual`. This change detects that state and executes the appropriate command in the `run` script.

There's some documentation in https://pre-commit.com/#confining-hooks-to-run-at-certain-stages