### PR TITLE
Preserve executable bit in files

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -163,7 +163,10 @@ let
     runCommand "pre-commit-run" { buildInputs = [ git ]; } ''
       set +e
       HOME=$PWD
-      cp --no-preserve=mode -R ${cfg.rootSrc} src
+      # Use `chmod +w` instead of `cp --no-preserve=mode` to be able to write and to
+      # preserve the executable bit at the same time
+      cp -R ${cfg.rootSrc} src
+      chmod -R +w src
       ln -fs ${configFile} src/.pre-commit-config.yaml
       cd src
       rm -rf src/.git


### PR DESCRIPTION
This changes the pre-commit-run to preserve the executable bit of the files-to-check.

Some commit hooks such as `pre-commit-hooks/check-executables-have-shebangs` are designed to run only on executable files via `types = ["executable"]` and the python tool identify uses the executable bit of a file when generating file tags, so `executable` is only listed when that bit is set.

If we don't preserve the executable bit, results of a local pre-commit invocation and the `pre-commit-check` might differ.

This was easy to test using the `check-executables-have-shebangs` hook:

```nix
      check-executables-have-shebangs = {
        enable = true;
        name = "Check that executables have shebangs";
        description = "Ensures that (non-binary) executables have a shebang.";
        entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/check-executables-have-shebangs";
        types = [ "text" "executable" ];
      }
```

The git output of `run` is very helpful as well because it shows the file mode.