### PR TITLE
Fix rustfmt hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -313,7 +313,7 @@ in
             nativeBuildInputs = [ pkgs.makeWrapper ];
             postBuild = ''
               wrapProgram $out/bin/cargo-fmt \
-                --prefix PATH : ${lib.makeBinPath [ tools.cargo ]}
+                --prefix PATH : ${lib.makeBinPath [ tools.cargo tools.rustfmt ]}
             '';
           };
         in


### PR DESCRIPTION
This MR fixes the rustfmt hook as suggested in https://github.com/cachix/pre-commit-hooks.nix/issues/126#issuecomment-1242603744

I tested it with my [minimal reproducible example](https://github.com/m1-s/pre-commit-hooks-nix-clippy) and it worked.

Relates to #126