### PR TITLE
Make cabal2nix work in subdirectories as well

### DIFF
--- a/nix/cabal2nix-dir/default.nix
+++ b/nix/cabal2nix-dir/default.nix
@@ -1,10 +1,11 @@
 { writeScriptBin, cabal2nix }:
 
 writeScriptBin "cabal2nix-dir" ''#!/usr/bin/env bash
+  projectdir="$(pwd)"
   for cabalFile in "''$@"; do
     echo "$cabalFile"
     dir="$(dirname $cabalFile)"
-    defaultFile="$dir/default.nix"
-    ${cabal2nix}/bin/cabal2nix --no-hpack "$dir" > "$defaultFile"
+    cd "$projectdir/$dir"
+    ${cabal2nix}/bin/cabal2nix --no-hpack . > default.nix
   done
 ''


### PR DESCRIPTION
Before this PR, the `cabal2nix` hook would only work correctly with the `src` attribute if the cabal file was in the root of the repository.