### PR TITLE
Add setting to configure nixfmt line width

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -113,6 +113,15 @@ in
               default = [ ];
             };
         };
+      nixfmt =
+        {
+          width =
+            mkOption {
+              type = types.nullOr types.int;
+              description = lib.mdDoc "Line width.";
+              default = null;
+            };
+        };
       prettier =
         {
           binPath =
@@ -339,7 +348,7 @@ in
         {
           name = "nixfmt";
           description = "Nix code prettifier.";
-          entry = "${tools.nixfmt}/bin/nixfmt";
+          entry = "${tools.nixfmt}/bin/nixfmt ${lib.optionalString (settings.nixfmt.width != null) "--width=${toString settings.nixfmt.width}"}";
           files = "\\.nix$";
         };
       nixpkgs-fmt =


### PR DESCRIPTION
```console
> nixfmt --help
nixfmt v0.5.0

nixfmt [OPTIONS] [FILES]
  Format Nix source code

Common flags:
  -w --width=INT        Maximum width in characters
  -c --check            Check whether files are formatted
  -q --quiet            Do not report errors
  -v --verify           Check that the output parses and formats the same as
                        the input
  -? --help             Display help message
  -V --version          Print version information
     --numeric-version  Print just the version number
```