### PR TITLE
Remove types_or from shellcheck hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -406,16 +406,6 @@ in
           name = "shellcheck";
           description = "Format shell files.";
           types = [ "shell" ];
-          types_or =
-            # based on `goodShells` in https://github.com/koalaman/shellcheck/blob/master/src/ShellCheck/Parser.hs
-            [
-              "sh"
-              "ash"
-              "bash"
-              "bats"
-              "dash"
-              "ksh"
-            ];
           entry = "${tools.shellcheck}/bin/shellcheck";
         };
       stylua =


### PR DESCRIPTION
This made the pre-commit configuration work with shell files. Otherwise it works only with `.bash` files. I couldn't really figure out why that's the case by looking at how pre-commit filtering works.

Tested on macOS 10.15.7 (Intel i7) and 12.6 (Apple M1 Max) using both bash and zsh.
