### PR TITLE
Add typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ use nix
 ## Spell checkers
 
 - [hunspell](https://github.com/hunspell/hunspell)
+- [typos](https://github.com/crate-ci/typos)
 
 ## Other Formatters
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -154,6 +154,29 @@ in
               default = "\\.js$";
             };
         };
+      typos =
+        {
+          write =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Whether to write fixes out.";
+              default = false;
+            };
+
+          diff =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Wheter to print a diff of what would change.";
+              default = false;
+            };
+
+          format =
+            mkOption {
+              type = types.enum [ "silent" "brief" "long" "json" ];
+              description = lib.mdDoc "Output format.";
+              default = "long";
+            };
+        };
 
       revive =
         {
@@ -528,6 +551,13 @@ in
           description = "Spell checker and morphological analyzer.";
           entry = "${tools.hunspell}/bin/hunspell -l";
           files = "\\.((txt)|(html)|(xml)|(md)|(rst)|(tex)|(odf)|\\d)$";
+        };
+      typos =
+        {
+          name = "typos";
+          description = "Source code spell checker";
+          entry = with settings.typos;
+            "${tools.typos}/bin/typos --format ${format} ${lib.optionalString write "-w"} ${lib.optionalString diff "--diff"}";
         };
       html-tidy =
         {

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -36,6 +36,7 @@
 , stylish-haskell
 , stylua
 , texlive
+, typos
 , writeScript
 , writeText
 , go
@@ -43,7 +44,7 @@
 }:
 
 {
-  inherit actionlint alejandra cabal-fmt cabal2nix cargo clang-tools clippy deadnix dhall hadolint hindent hlint hpack html-tidy nix-linter nixfmt nixpkgs-fmt ormolu rustfmt shellcheck shfmt statix stylish-haskell stylua go mdsh revive;
+  inherit actionlint alejandra cabal-fmt cabal2nix cargo clang-tools clippy deadnix dhall hadolint hindent hlint hpack html-tidy nix-linter nixfmt nixpkgs-fmt ormolu rustfmt shellcheck shfmt statix stylish-haskell stylua typos go mdsh revive;
   inherit (elmPackages) elm-format elm-review elm-test;
   # TODO: these two should be statically compiled
   inherit (haskellPackages) brittany fourmolu;


### PR DESCRIPTION
Add [typos](https://github.com/crate-ci/typos) source code spell checker.

By default, it does not writes changes to file, an option is added to change the behavior.

Closure size is `21M` according to `du -sh $(nix-build -A typos)`.