### PR TITLE
Add editorconfig-checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ use nix
 - `dhall format`: built-in formatter
 - [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
 - [hadolint](https://github.com/hadolint/hadolint)
+- [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)
 
 You must configure which languages should be formatted by `clang_format` using
 `clang-format.types_or`. For example to check both C and C++ files:

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -278,7 +278,7 @@ in
           # 2. Below which there are haskell files, or
           # 3. In which there is a package.yaml that references haskell files
           #    that have been changed at arbitrary locations specified in that
-          #    file. 
+          #    file.
           # In other words: We have no choice but to always run `hpack` on every `package.yaml` directory.
           pass_filenames = false;
         };
@@ -664,6 +664,14 @@ in
             # all file names in a single run.
             require_serial = true;
           };
+        };
+
+      editorconfig-checker =
+        {
+          name = "editorconfig-checker";
+          description = "Verify that the files are in harmony with the `.editorconfig`.";
+          entry = "${tools.editorconfig-checker}/bin/editorconfig-checker";
+          types = [ "file" ];
         };
 
     };

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -9,6 +9,7 @@
 , clippy
 , deadnix
 , dhall
+, editorconfig-checker
 , elmPackages
 , git
 , gitAndTools
@@ -44,7 +45,7 @@
 }:
 
 {
-  inherit actionlint alejandra cabal-fmt cabal2nix cargo clang-tools clippy deadnix dhall hadolint hindent hlint hpack html-tidy nix-linter nixfmt nixpkgs-fmt ormolu rustfmt shellcheck shfmt statix stylish-haskell stylua typos go mdsh revive;
+  inherit actionlint alejandra cabal-fmt cabal2nix cargo clang-tools clippy deadnix dhall editorconfig-checker hadolint hindent hlint hpack html-tidy nix-linter nixfmt nixpkgs-fmt ormolu rustfmt shellcheck shfmt statix stylish-haskell stylua typos go mdsh revive;
   inherit (elmPackages) elm-format elm-review elm-test;
   # TODO: these two should be statically compiled
   inherit (haskellPackages) brittany fourmolu;


### PR DESCRIPTION
Add [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker).

Closure size is 3.7M according to `du -sh $(nix-build -A editorconfig-checker)`.