### PR TITLE
Add pre-commit-hook-ensure-sops

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685866647,
-        "narHash": "sha256-4jKguNHY/edLYImB+uL8jKPL/vpfOvMmSlLAGfxSrnY=",
+        "lastModified": 1689261696,
+        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a53a3bec10deef6e1cc1caba5bc60f53b959b1e8",
+        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
         "type": "github"
       },
       "original": {

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1018,9 +1018,16 @@ in
         };
       pre-commit-hook-ensure-sops = {
         name = "pre-commit-hook-ensure-sops";
-        entry = ''
-          ${tools.pre-commit-hook-ensure-sops}/bin/pre-commit-hook-ensure-sops
-        '';
+        entry =
+          ## NOTE: pre-commit-hook-ensure-sops landed in nixpkgs on 8 July 2022. Once it reaches a
+          ## release of NixOS, the `throwIf` piece of code below will become
+          ## useless.
+          lib.throwIf
+            (tools.pre-commit-hook-ensure-sops == null)
+            "The version of nixpkgs used by pre-commit-hooks.nix does not have the `pre-commit-hook-ensure-sops` package. Please use a more recent version of nixpkgs."
+            ''
+              ${tools.pre-commit-hook-ensure-sops}/bin/pre-commit-hook-ensure-sops
+            '';
         files = lib.mkDefault "^secrets";
       };
       hunspell =

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1016,6 +1016,13 @@ in
             "${binPath} ${lib.optionalString write "--write"} ${lib.optionalString (output != null) "--${output}"} --ignore-unknown";
           types = [ "text" ];
         };
+      pre-commit-hook-ensure-sops = {
+        name = "pre-commit-hook-ensure-sops";
+        entry = ''
+          ${tools.pre-commit-hook-ensure-sops}/bin/pre-commit-hook-ensure-sops
+        '';
+        files = lib.mkDefault "^secrets";
+      };
       hunspell =
         {
           name = "hunspell";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -41,6 +41,7 @@
 , opam
 , ormolu
 , pkgsBuildBuild
+, pre-commit-hook-ensure-sops
 , python39Packages
 , ruff ? null
 , runCommand
@@ -100,6 +101,7 @@ in
     nixpkgs-fmt
     opam
     ormolu
+    pre-commit-hook-ensure-sops
     revive
     ruff
     rustfmt

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -41,7 +41,7 @@
 , opam
 , ormolu
 , pkgsBuildBuild
-, pre-commit-hook-ensure-sops
+, pre-commit-hook-ensure-sops ? null
 , python39Packages
 , ruff ? null
 , runCommand


### PR DESCRIPTION
As suggested (by me) here #208, I have implemented [`pre-commit-hook-ensure-sops`](https://github.com/yuvipanda/pre-commit-hook-ensure-sops) as a hook in this pull request.

Some notes/questions/problems:

- There is no separate repository where the package itself is in (e.g., `nixpkgs`) so I have packaged it in `./nix/tools/pre-commit-hook-ensure-sops`. I suppose this is not ideal (?). If it first should be added in `nixpkgs` I can do the pull request there.
- The name is pretty verbose but matches the name of the original repository. Could be changed but then there is the chance for confusion of what the hook is based on originally.
- The secret files made by `sops` can have (any) file extensions and part of the check is making sure all files are valid `yaml` (i.e., `json` is accepted). Therefore, I do not know of a way of how to target the hook by default. Currently I implemented it to target all files within a `secrets` directory with the pattern `^secrets`. This unlikely matches the namings of other repositories but then the users can just override the value. Any other options or suggestions?

Let me know what you think! I will modify the pull request as suggested.