### PR TITLE
Add phpstan and psalm hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ use nix
 - [php-cs-fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer)
 - [phpcbf](https://github.com/squizlabs/PHP_CodeSniffer)
 - [phpcs](https://github.com/squizlabs/PHP_CodeSniffer)
+- [phpstan](https://phpstan.org/)
+- [psalm](https://psalm.dev/)
 
 ## Rust
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -832,7 +832,7 @@ in
           name = "phpstan";
           description = "Static analyzer for PHP files.";
           entry = with settings.phpstan;
-            "${binPath} analyse -- ";
+            "${binPath} analyse --";
           types = [ "php" ];
         };
 
@@ -841,7 +841,7 @@ in
           name = "psalm";
           description = "Static analyzer for PHP files.";
           entry = with settings.psalm;
-            "${binPath}";
+            "${binPath} --no-cache";
           types = [ "php" ];
         };
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -244,6 +244,32 @@ in
             };
         };
 
+      phpstan =
+        {
+          binPath =
+            mkOption {
+              type = types.str;
+              description = lib.mdDoc "PHPStan binary path.";
+              default = "${pkgs.phpPackages.phpstan}/bin/phpstan";
+              defaultText = lib.literalExpression ''
+                "''${pkgs.phpPackages.phpstan}/bin/phpstan"
+              '';
+            };
+        };
+
+      psalm =
+        {
+          binPath =
+            mkOption {
+              type = types.str;
+              description = lib.mdDoc "Psalm binary path.";
+              default = "${pkgs.phpPackages.psalm}/bin/psalm";
+              defaultText = lib.literalExpression ''
+                "''${pkgs.phpPackages.psalm}/bin/psalm"
+              '';
+            };
+        };
+
       pylint =
         {
           binPath =
@@ -798,6 +824,24 @@ in
           description = "Lint PHP files.";
           entry = with settings.php-cs-fixer;
             "${binPath} fix";
+          types = [ "php" ];
+        };
+
+      phpstan =
+        {
+          name = "phpstan";
+          description = "Static analyzer for PHP files.";
+          entry = with settings.phpstan;
+            "${binPath} analyse -- ";
+          types = [ "php" ];
+        };
+
+      psalm =
+        {
+          name = "psalm";
+          description = "Static analyzer for PHP files.";
+          entry = with settings.psalm;
+            "${binPath}";
           types = [ "php" ];
         };
 


### PR DESCRIPTION
These unfortunately won't work very well until https://github.com/NixOS/nixpkgs/pull/207605 is merged.

In theory, you could use the binPath options with [composer2nix] (with noDev = false), however SHA1 verification of the phar fails, presumably due to path patching in composer2nix.

```nix
{
  phpstan.binPath = let
    composition = (import ./nix/composition.nix) {
      inherit system pkgs php;
      phpPackages = php.packages;
    };
  in "${composition}/vendor/bin/phpstan";
}
```

In my project, I've just vendored the phpstan and psalm derivations from the referenced PR for now, but I'm not sure that's appropriate here.

[composer2nix]: https://github.com/svanderburg/composer2nix