### PR TITLE
docs: add actionlint

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ use nix
 - [clang-format](https://clang.llvm.org/docs/ClangFormat.html)
 - [hadolint](https://github.com/hadolint/hadolint)
 - [editorconfig-checker](https://github.com/editorconfig-checker/editorconfig-checker)
+- [actionlint](https://github.com/rhysd/actionlint)
 
 You must configure which languages should be formatted by `clang_format` using
 `clang-format.types_or`. For example to check both C and C++ files:


### PR DESCRIPTION
The actionlint hook was added in #165. This commit adds it to the
readme.