### PR TITLE
Add option to fail when clippy emits warnings

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -313,6 +313,16 @@ in
             default = false;
           };
         };
+
+      clippy =
+        {
+          denyWarnings = mkOption {
+            type = types.bool;
+            description = lib.mdDoc "Fail when warnings are present";
+            default = false;
+          };
+        };
+
     };
 
   config.hooks =
@@ -648,7 +658,7 @@ in
         {
           name = "clippy";
           description = "Lint Rust code.";
-          entry = "${wrapper}/bin/cargo-clippy clippy ${cargoManifestPathArg}";
+          entry = "${wrapper}/bin/cargo-clippy clippy ${cargoManifestPathArg} -- ${lib.optionalString settings.clippy.denyWarnings "-D warnings"}";
           files = "\\.rs$";
           pass_filenames = false;
         };


### PR DESCRIPTION
This makes it possible for projects to use clippy to enforce lints without using `#![deny(warnings)]` (considered harmful ™️)