### PR TITLE
Stop go hooks being enabled by default

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -772,7 +772,6 @@ in
         };
 
       gotest = {
-        enable = true;
         name = "gotest";
         description = "Run go tests";
         entry =
@@ -873,7 +872,6 @@ in
 
       staticcheck =
         {
-          enable = true;
           name = "staticcheck";
           description = "State of the art linter for the Go programming language";
           # staticheck works with directories.


### PR DESCRIPTION
#222 inadvertently enabled its new hooks by default. This PR reverses that change.