### PR TITLE
fix: allow .git directory on parent directory

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -366,7 +366,7 @@ in
           if ! type -t git >/dev/null; then
             # This happens in pure shells, including lorri
             echo 1>&2 "WARNING: pre-commit-hooks.nix: git command not found; skipping installation."
-          elif [[ ! -e .git ]]; then
+          elif ! ${git}/bin/git rev-parse --git-dir &> /dev/null; then
             echo 1>&2 "WARNING: pre-commit-hooks.nix: .git not found; skipping installation."
           else
             # These update procedures compare before they write, to avoid


### PR DESCRIPTION
Currently, the check to validate pre-commit-hooks is getting installed on a git repository only considers the `.git` directory if the pre-commit-hooks config is at the root path; if the pre-commit-hooks config lives in another path that is not the root of the repository, pre-commit-hooks won't install a script.

This change allows `flake.nix` files in sub-directories to have the pre-commit-hooks configuration. This is especially common in monorepos.

Note, this change requires a [PR on `nixpkgs`](https://github.com/NixOS/nixpkgs/pull/210256) to be merged before this code works.

resolves #224 