### PR TITLE
feat: add bats checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ use nix
 
 - [shellcheck](https://github.com/koalaman/shellcheck)
 - [shfmt](https://github.com/mvdan/sh)
+- [bats](https://github.com/bats-core/bats-core)
 
 ## Lua
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -605,6 +605,14 @@ in
             ];
           entry = "${tools.shellcheck}/bin/shellcheck";
         };
+      bats =
+        {
+          name = "bats";
+          description = "Run bash unit tests.";
+          types = [ "shell" ];
+          types_or = [ "bats" "bash" ];
+          entry = "${tools.bats}/bin/bats -p";
+        };
       stylua =
         {
           name = "stylua";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -33,6 +33,7 @@
 , runCommand
 , rustfmt
 , shellcheck
+, bats
 , shfmt
 , statix
 , stylish-haskell
@@ -69,4 +70,5 @@ in
   latexindent = tex;
   chktex = tex;
   commitizen = commitizen.overrideAttrs (_: _: { doCheck = false; });
+  bats = if bats ? withLibraries then (bats.withLibraries (p: [ p.bats-support p.bats-assert p.bats-file ])) else bats;
 }


### PR DESCRIPTION
### Context

As a bash developer
I want to run tests on pre-commit
So that I don't introduce bugs in my bash logic

### Summary

This extension allows us to run the [`bats`](https://bats-core.readthedocs.io/en/stable/) utility.