### PR TITLE
fix(pre-commit-run): Remove .git directory

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -174,7 +174,7 @@ let
       chmod -R +w src
       ln -fs ${configFile} src/.pre-commit-config.yaml
       cd src
-      rm -rf src/.git
+      rm -rf .git
       git init
       git add .
       git config --global user.email "you@example.com"


### PR DESCRIPTION
It seems like this is the intention of the code, but currently the `rm` command deletes nothing, and doesn't fail because it is given the `-f` flag.