### PR TITLE
Improve and fix `hpack` hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -422,7 +422,7 @@ in
           description =
             "`hpack` converts package definitions in the hpack format (`package.yaml`) to Cabal files.";
           entry = "${tools.hpack-dir}/bin/hpack-dir --${if settings.hpack.silent then "silent" else "verbose"}";
-          files = "(\\.l?hs(-boot)?$)|(^[^/]+\\.cabal$)|(^package\\.yaml$)";
+          files = "(\\.l?hs(-boot)?$)|(\\.cabal$)|((^|/)package\\.yaml$)";
           # We don't pass filenames because they can only be misleading.
           # Indeed, we need to rerun `hpack` in every directory:
           # 1. In which there is a *.cabal file, or

--- a/nix/hpack-dir/default.nix
+++ b/nix/hpack-dir/default.nix
@@ -1,9 +1,20 @@
 { writeScriptBin, hpack }:
 
 writeScriptBin "hpack-dir" ''#!/usr/bin/env bash
+  set -e
+  ##  ^^
+  ## The `-e` flag changes the behaviour of Shell so that the first top-level
+  ## failure of a command causes failure of the whole script.
+
   if [ "$1" == "--silent" ]; then
     flag=$1
   fi
 
-  find . -type f -name 'package.yaml' -exec hpack --force $flag {} \;
+  find . -type f -name package.yaml | while read -r file; do
+    ${hpack}/bin/hpack --force $flag "$file"
+    ##           ^^^^^
+    ## The `find | while` pattern has for upside that it puts this `hpack` call
+    ## at toplevel. In conjunction with the `-e` flag above, this ensures that
+    ## a failure of `hpack` will lead to a failure of the pre-commit hook.
+  done
 ''


### PR DESCRIPTION
closes #235

Following https://github.com/cachix/pre-commit-hooks.nix/issues/235, here is a PR that improves and fixes the `hpack` hook.

## Changes

### ...to the `files` pattern

First, we update the `files` pattern to match `*.cabal` and `package.yaml` files everywhere in the repository and not at the root. The `files` pattern's components change in the following way:

- The first part, `\\.l?hs(-boot)?$`, remains the same. To be honest, I do not understand why this part is useful or necessary. But I did not take the liberty to remove it.
- The second part, `^[^/]+\\.cabal$`, changes to `\\.cabal$`. This makes it match any `*.cabal` file in the repository, while the previous version matched only `*.cabal` files at top-level.
- The third part, `^package\\.yaml$`, changes to `(^|/)package\\.yaml$`. Once again, this makes it match any `package.yaml` file in the repository while the previous version matched them only at top-level.

The `files` pattern matches on the files's paths and not just the names. I did not find any direct reference to that in the documentation of pre-commit. However, its section [“Filtering files with types”](https://pre-commit.com/#filtering-files-with-types) mentions the following examples:
![image](https://user-images.githubusercontent.com/5920602/215501923-0832c4e7-782d-4379-982f-d7d594640230.png)

### ...to the `hpack-dir` script

Second, we rewrite the `hpack-dir` script to achieve two things:

1. We replace the call to `hpack` by a call to `${hpack}/bin/hpack`. This ensures that the script works also when `hpack` is not present on the machine. This also increases reliability by giving better control to `hpack`'s version being used in the hook.

2. The previous version also failed silently in case of errors of `hpack` (or error caused by the absence of `hpack`). We suggest a replacement based on `set -e` and `find | while`. This design choice is heavily documented in the script itself.

## Experiments

I have introduced this “fixed” version of the hook in two of Tweag's projects: https://github.com/tweag/pirouette/pull/177 and https://github.com/tweag/plutus-libs/pull/226. I ran some tests locally by hand on both those projects, and also in CI; all have proven successful. The first project has its `package.yaml` and `*.cabal` project at top-level and the second within sub-directories.