### PR TITLE
Add luacheck, chktex, and latexindent to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ use nix
 
 ## Lua
 
+- [luacheck](https://github.com/mpeterv/luacheck)
 - [stylua](https://github.com/JohnnyMorganz/StyLua)
 
 ## HTML

--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ use nix
 - [shfmt](https://github.com/mvdan/sh)
 - [bats](https://github.com/bats-core/bats-core)
 
+## LaTeX
+
+- [chktex](https://www.nongnu.org/chktex/)
+- [latexindent](https://github.com/cmhughes/latexindent.pl)
+
 ## Lua
 
 - [luacheck](https://github.com/mpeterv/luacheck)


### PR DESCRIPTION
Some checkers introduced in #165 were not added to the README. This patch adds them.