### PR TITLE
latexindent: fix unknown command line option

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -463,7 +463,7 @@ in
           name = "latexindent";
           description = "Perl script to add indentation to LaTeX files.";
           types = [ "file" "tex" ];
-          entry = "${tools.latexindent}/bin/latexindent --local --silent --modifyIfDifferent";
+          entry = "${tools.latexindent}/bin/latexindent --local --silent --overwriteIfDifferent";
         };
       luacheck =
         {


### PR DESCRIPTION
The `--modifyIfDifferent` argument passed to `latexindent` should be `--overwriteIfDifferent`

See the [latexindent manual](https://ctan.math.washington.edu/tex-archive/support/latexindent/documentation/latexindent.pdf), page 15.