### PR TITLE
add zprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ use nix
 - [cabal-fmt](https://github.com/phadej/cabal-fmt)
 - [hpack](https://github.com/sol/hpack)
 
+## Clojure
+
+- [zprint](https://github.com/kkinnear/zprint)
+
 ## Elm
 
 - [elm-format](https://github.com/avh4/elm-format)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1015,6 +1015,14 @@ in
           types = [ "toml" ];
         };
 
+      zprint =
+        {
+          name = "zprint";
+          description = "Beautifully format Clojure and Clojurescript source code and s-expressions.";
+          entry = "${pkgs.zprint}/bin/zprint '{:search-config? true}' -w";
+          types_or = [ "clojure" "clojurescript" "edn" ];
+        };
+
       commitizen =
         {
           name = "commitizen check";


### PR DESCRIPTION
Adds the zprint formatter for Clojure(Script).

zprint's closure size is 57MB, a little over the 50MB limit. Not sure how strict that is, and at least people looking for it might find this PR with how to implement it, even if it's not merged :).