### PR TITLE
Add nil hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ use nix
 
 - [alejandra](https://github.com/kamadorueda/alejandra)
 - [deadnix](https://github.com/astro/deadnix)
+- [nil](https://github.com/oxalica/nil)
 - [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)
 - [nixfmt](https://github.com/serokell/nixfmt/)
 - [statix](https://github.com/nerdypepper/statix)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -597,6 +597,13 @@ in
           entry = settings.mypy.binPath;
           files = "\\.py$";
         };
+      nil =
+        {
+          name = "nil";
+          description = "Incremental analysis assistant for writing in Nix.";
+          entry = "${tools.nil}/bin/nil diagnostics";
+          files = "\\.nix$";
+        };
       nixfmt =
         {
           name = "nixfmt";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -25,6 +25,7 @@
 , hunspell
 , luaPackages
 , mdsh
+, nil
 , nixfmt
 , nixpkgs-fmt
 , nodePackages
@@ -60,7 +61,7 @@ let
   };
 in
 {
-  inherit actionlint ansible-lint alejandra cabal-fmt cabal2nix cargo clang-tools clippy deadnix dhall editorconfig-checker hadolint hindent hlint hpack html-tidy nixfmt nixpkgs-fmt opam ormolu rustfmt shellcheck shfmt statix stylish-haskell stylua tagref typos go mdsh revive go-tools yamllint ruff;
+  inherit actionlint ansible-lint alejandra cabal-fmt cabal2nix cargo clang-tools clippy deadnix dhall editorconfig-checker hadolint hindent hlint hpack html-tidy nil nixfmt nixpkgs-fmt opam ormolu rustfmt shellcheck shfmt statix stylish-haskell stylua tagref typos go mdsh revive go-tools yamllint ruff;
   inherit (elmPackages) elm-format elm-review elm-test;
   # TODO: these two should be statically compiled
   inherit (haskellPackages) fourmolu;


### PR DESCRIPTION
[Nil](https://github.com/oxalica/nil) is a language server and an incremental analysis assistant for writing in Nix. It supports checking files with `nil diagnostics`.

See https://github.com/oxalica/nil/blob/main/docs/features.md for supported diagnostics.

I tested the hook on my personal NixOS configuration and it worked fine.