### PR TITLE
configPath option for ansible-lint

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -21,6 +21,21 @@ in
 {
   options.settings =
     {
+      ansible-lint =
+        {
+          configPath = mkOption {
+            type = types.str;
+            description = "path to the configuration YAML file";
+            # an empty string translates to use default configuration of the
+            # underlying ansible-lint binary
+            default = "";
+          };
+          subdir = mkOption {
+            type = types.str;
+            description = "path to Ansible subdir";
+            default = "";
+          };
+        };
       hpack =
         {
           silent =
@@ -385,7 +400,15 @@ in
           name = "ansible-lint";
           description =
             "Ansible linter.";
-          entry = "${tools.ansible-lint}/bin/ansible-lint";
+          entry =
+            let
+              cmdArgs =
+                mkCmdArgs [
+                  [ (settings.ansible-lint.configPath != "") "-c ${settings.ansible-lint.configPath}" ]
+                ];
+            in
+            "${tools.ansible-lint}/bin/ansible-lint ${cmdArgs}";
+          files = if settings.ansible-lint.subdir != "" then "${settings.ansible-lint.subdir}/" else "";
         };
       black =
         {


### PR DESCRIPTION
Using pre-commit-hooks for Ansible code located inside a subdirectory is not currently supported:
* `ansible-lint` binary cannot find default config files (`.ansible-lint` & `.config/ansible-lint.yml`) as it is ran from repository's root
* Other `.yml` files are analyzed (e.g. CI/CD config files) for the same reason

We could `cd <subdir>` but that would invalidate `pass_filenames = true` option as explained here: https://github.com/pre-commit/pre-commit/issues/1417#issuecomment-1208212944

Suggestions are welcome!

----
* `configPath` implementation is based on `yamllint`'s.