### PR TITLE
nil: fix issue with multiple files

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -601,7 +601,15 @@ in
         {
           name = "nil";
           description = "Incremental analysis assistant for writing in Nix.";
-          entry = "${tools.nil}/bin/nil diagnostics";
+          entry =
+            let
+              script = pkgs.writeShellScript "precommit-nil" ''
+                for file in $(echo "$@"); do
+                  ${tools.nil}/bin/nil diagnostics "$file"
+                done
+              '';
+            in
+            builtins.toString script;
           files = "\\.nix$";
         };
       nixfmt =


### PR DESCRIPTION
I've just implemented support for [nil](https://github.com/oxalica/nil) in #253, but I made a mistake and the hook only functions when a single file has been modified. I apologize for any inconvenience this may have caused.

The current behavior of nil diagnostics expects only one file, and if invoked with multiple files, it fails and produces an error message such as "Unrecognized argument: file2.nix". To address this issue, this commit introduces a straightforward wrapper script that iterates through all files and executes nil diagnostics on each one.