### PR TITLE
add lua-language-server typecheck/lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ use nix
 
 - [luacheck](https://github.com/mpeterv/luacheck)
 - [stylua](https://github.com/JohnnyMorganz/StyLua)
+- [lua-ls](https://github.com/LuaLS/lua-language-server)
 
 ## HTML
 

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -30,6 +30,7 @@
 , html-tidy
 , hunspell
 , luaPackages
+, sumneko-lua-language-server
 , mdsh
 , nil
 , nixfmt
@@ -117,6 +118,7 @@ in
   inherit (luaPackages) luacheck;
   inherit (nodePackages) eslint markdownlint-cli prettier cspell;
   inherit (ocamlPackages) ocp-indent;
+  lua-language-server = sumneko-lua-language-server;
   purs-tidy = nodePackages.purs-tidy or null;
   cabal2nix-dir = callPackage ./cabal2nix-dir { };
   hpack-dir = callPackage ./hpack-dir { };


### PR DESCRIPTION
`lua-language-server` can be used to statically type-check lua code bases.
This is especially useful if the code base uses [emmylua type annotations](https://emmylua.github.io/annotation.html).

Here are some usage examples:

* The [check I have based this hook on](https://github.com/mrcjkb/neotest-haskell/blob/master/nix/ci-overlay.nix#L96).
* A PR in which I have added this pre-commit hook: https://github.com/nvim-neorocks/luarocks-tag-release/pull/45/

```console
du -sh $(nix-build -A lua-language-server)
22M	/nix/store/687lpp90g18p3gzb8cyznnqkizaqzzll-lua-language-server-3.6.18
```