### PR TITLE
flake-parts: add `devShell` option

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -55,6 +55,11 @@ in
               defaultText = lib.literalDocBook "bash statements";
               readOnly = true;
             };
+            devShell = mkOption {
+              type = types.package;
+              description = lib.mdDoc "A development shell with pre-commit installed and setup.";
+              readOnly = true;
+            };
           };
         };
         config = {
@@ -64,6 +69,10 @@ in
             package = lib.mkDefault pkgs.pre-commit;
             tools = import ./nix/call-tools.nix pkgs;
             settings.treefmt.package = lib.mkIf (options?treefmt) (lib.mkDefault config.treefmt.build.wrapper);
+          };
+          pre-commit.devShell = pkgs.mkShell {
+            nativeBuildInputs = [ cfg.settings.package ];
+            shellHook = cfg.installationScript;
           };
         };
       });

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -25,6 +25,7 @@
           # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
           packages.hello = pkgs.hello;
           pre-commit.settings.hooks.nixpkgs-fmt.enable = true;
+          # NOTE: You can also use `config.pre-commit.devShell`
           devShells.default = pkgs.mkShell {
             shellHook = ''
               ${config.pre-commit.installationScript}


### PR DESCRIPTION
Having flake-parts modules expose a `devShell` like this is really useful when the user has a top-level devShell and they want to "compose" other devShells using `inputsFrom`.

cf. https://github.com/srid/haskell-flake/issues/135

cc @roberth 