### PR TITLE
rustfmt: remove --check

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -763,7 +763,7 @@ in
         {
           name = "rustfmt";
           description = "Format Rust code.";
-          entry = "${wrapper}/bin/cargo-fmt fmt ${cargoManifestPathArg} -- --check --color always";
+          entry = "${wrapper}/bin/cargo-fmt fmt ${cargoManifestPathArg} -- --color always";
           files = "\\.rs$";
           pass_filenames = false;
         };


### PR DESCRIPTION
Removes the --check argument of rustfmt. Using `--check` to ensure files are not touched is inconsistent with the other pre-commit hooks.