### PR TITLE
Fix lazy docs

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -471,7 +471,7 @@ in
         ## the `dune-project` file has changed.
         pass_filenames = false;
       };
-      gptcommit = lib.optionalAttrs (tools.gptcommit != null) {
+      gptcommit = {
         name = "gptcommit";
         description = "Generate a commit message using GPT3.";
         entry =

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -481,7 +481,9 @@ in
                 "$PRE_COMMIT_COMMIT_MSG_SOURCE" --commit-msg-file "$1"
             '';
           in
-          toString script;
+          lib.throwIf (tools.gptcommit == null) "The version of Nixpkgs used by pre-commit-hooks.nix does not have the `gptcommit` package. Please use a more recent version of Nixpkgs."
+            toString
+            script;
         stages = [ "prepare-commit-msg" ];
       };
       hlint =


### PR DESCRIPTION
 - Fixes docs
   - The docs should not depend on anything `system`-specific like `tools`.
 - Improves error message when gptcommit is missing