### PR TITLE
Add `--fix` to ruff

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -426,7 +426,7 @@ in
         {
           name = "ruff";
           description = " An extremely fast Python linter, written in Rust.";
-          entry = "${pkgs.ruff}/bin/ruff";
+          entry = "${pkgs.ruff}/bin/ruff --fix";
           types = [ "python" ];
         };
       cabal2nix =


### PR DESCRIPTION
Following #269, make `ruff` fix errors (edit files) by default instead of just reporting errors.