### PR TITLE
Add hook for `dune fmt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ use nix
 
 ## OCaml
 
+- [dune-fmt](https://dune.build/)
 - [dune-opam-sync](https://dune.build/)
 - [opam-lint](https://opam.ocaml.org/)
 - [ocp-indent](http://www.typerex.org/ocp-indent.html)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -411,6 +411,16 @@ in
               '';
           };
         };
+
+      dune-fmt =
+        {
+          auto-promote =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Whether to auto-promote the changes.";
+              default = "true";
+            };
+        };
     };
 
   config.hooks =
@@ -1196,6 +1206,15 @@ in
         description = "Auto-formatter for modern Fortran code.";
         types = [ "fortran " ];
         entry = "${tools.fprettify}/bin/fprettify";
+      };
+
+      dune-fmt = {
+        name = "dune-fmt";
+        description = "Runs Dune's formatters on the code tree.";
+        entry =
+          let auto-promote = if settings.dune-fmt.auto-promote then "--auto-promote" else "";
+          in "${pkgs.dune_3}/bin/dune build @fmt ${auto-promote}";
+        pass_filenames = false;
       };
     };
 }


### PR DESCRIPTION
[Dune](https://dune.readthedocs.io/en/stable/index.html) includes a command `dune fmt` that runs formatters on the whole code tree. This PR adds support in `pre-commit-hooks` for this command. A few notes:

- `dune fmt` formats the `dune` files, OCaml files and ReasonML files. It is possible to change this behaviour by adding eg. `(formatting (enabled_for reason))` to `dune-project`, and therefore I don't think it makes much sense to add parameters for this in `pre-commit-hooks`. Should this be documented somewhere in `pre-commit-hooks`'s documentation?

- `dune fmt` only exists since Dune 3.2. It isn't this recent, but anyways. `dune fmt` is an alias for `dune build @fmt --auto-promote` whose behaviour hasn't changed since Dune 2.0, so I decided to use that instead. It then allowed me to add an option to disable the `--auto-promote` behaviour; it is the default but some people might not like it.