### PR TITLE
Add a hook for `headache`

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ use nix
 - [treefmt](https://github.com/numtide/treefmt)
 - [topiary](https://github.com/tweag/topiary)
 - [checkmake](https://github.com/mrtazz/checkmake)
+- [headache](https://github.com/frama-c/headache)
 
 You must configure which languages should be formatted by `clang_format` using
 `clang-format.types_or`. For example to check both C and C++ files:

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -421,6 +421,15 @@ in
               default = "true";
             };
         };
+
+      headache =
+        {
+          header-file = mkOption {
+            type = types.string;
+            description = lib.mdDoc "Path to the header file.";
+            default = ".header";
+          };
+        };
     };
 
   config.hooks =
@@ -1223,5 +1232,21 @@ in
           in "${pkgs.dune_3}/bin/dune build @fmt ${auto-promote}";
         pass_filenames = false;
       };
+
+      headache =
+        {
+          name = "headache";
+          description = "Lightweight tool for managing headers in source code files.";
+          ## NOTE: Supported `files` are taken from
+          ## https://github.com/Frama-C/headache/blob/master/config_builtin.txt
+          files = "(\\.ml[ily]?$)|(\\.fmli?$)|(\\.[chy]$)|(\\.tex$)|(Makefile)|(README)|(LICENSE)";
+          entry =
+            ## NOTE: `headache` made into in nixpkgs on 12 April 2023. At the
+            ## next NixOS release, the following code will become irrelevant.
+            lib.throwIf
+              (tools.headache == null)
+              "The version of nixpkgs used by pre-commit-hooks.nix does not have `ocamlPackages.headache`. Please use a more recent version of nixpkgs."
+              "${tools.headache}/bin/headache -h ${settings.headache.header-file}";
+        };
     };
 }

--- a/nix/headache/default.nix
+++ b/nix/headache/default.nix
@@ -1,0 +1,15 @@
+{ stdenv, lib, headache ? null, ocamlPackages }:
+
+## NOTE: `headache` moved from `ocamlPackages.headache` to top-level on 8 June
+## 2023. Once this gets into a NixOS release, the following code will be
+## useless.
+let the-headache = if headache != null then headache else ocamlPackages.headache; in
+
+## NOTE: The following derivation seems rather trivial, but it is used here to
+  ## get rid of a runtime dependency in the whole OCaml compiler (~420M).
+stdenv.mkDerivation {
+  name = "headache-stripped";
+  src = the-headache.src;
+  phases = [ "installPhase" ];
+  installPhase = "install -Dm 555 -t $out/bin ${lib.getExe the-headache}";
+}

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -91,8 +91,5 @@ in
   ## into a NixOS release, the following code will be useless.
   checkmake = if stdenv.isLinux || checkmake.version >= "0.2.2" then checkmake else null;
 
-  headache =
-    ## NOTE: `headache` made it into nixpkgs on 12 April 2023. At the next NixOS
-    ## release, the following code will become irrelevant.
-    if ocamlPackages ? headache then ocamlPackages.headache else null;
+  headache = callPackage ./headache { };
 }

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -90,4 +90,9 @@ in
   ## NOTE: `checkmake` 0.2.2 landed in nixpkgs on 12 April 2023. Once this gets
   ## into a NixOS release, the following code will be useless.
   checkmake = if stdenv.isLinux || checkmake.version >= "0.2.2" then checkmake else null;
+
+  headache =
+    ## NOTE: `headache` made it into nixpkgs on 12 April 2023. At the next NixOS
+    ## release, the following code will become irrelevant.
+    if ocamlPackages ? headache then ocamlPackages.headache else null;
 }


### PR DESCRIPTION
This PR adds a pre-commit hook for [headache](https://github.com/frama-c/headache), a “lightweight tool for managing headers in source code files.” `headache` was also added to nixpkgs quite recently, so I include a tiny hack similar to the one previously made for eg. `checkmake`.

My only worry for this PR is that the size of `headache`'s derivation is quite big. It isn't really a problem for OCaml projects that already rely on the same `nixpkgs`, but it is maybe a bit much for other projects.