### PR TITLE
Fix typo giving `dune-fmt`'s setting a wrong type

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -418,7 +418,7 @@ in
             mkOption {
               type = types.bool;
               description = lib.mdDoc "Whether to auto-promote the changes.";
-              default = "true";
+              default = true;
             };
         };
     };


### PR DESCRIPTION
Very sorry about this.