### PR TITLE
Wrap `dune fmt` in a clean written tool

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -420,6 +420,13 @@ in
               description = lib.mdDoc "Whether to auto-promote the changes.";
               default = true;
             };
+
+          extraRuntimeInputs =
+            mkOption {
+              type = types.listOf types.package;
+              description = lib.mdDoc "Extra runtimeInputs to add to the environment, eg. `ocamlformat`.";
+              default = [ ];
+            };
         };
     };
 
@@ -1219,8 +1226,15 @@ in
         name = "dune-fmt";
         description = "Runs Dune's formatters on the code tree.";
         entry =
-          let auto-promote = if settings.dune-fmt.auto-promote then "--auto-promote" else "";
-          in "${pkgs.dune_3}/bin/dune build @fmt ${auto-promote}";
+          let
+            auto-promote = if settings.dune-fmt.auto-promote then "--auto-promote" else "";
+            run-dune-fmt = pkgs.writeShellApplication {
+              name = "run-dune-fmt";
+              runtimeInputs = settings.dune-fmt.extraRuntimeInputs;
+              text = "${tools.dune-fmt}/bin/dune-fmt ${auto-promote}";
+            };
+          in
+          "${run-dune-fmt}/bin/run-dune-fmt";
         pass_filenames = false;
       };
     };

--- a/nix/dune-fmt/default.nix
+++ b/nix/dune-fmt/default.nix
@@ -1,0 +1,7 @@
+{ writeShellApplication, dune, ocaml }:
+
+writeShellApplication {
+  name = "dune-fmt";
+  runtimeInputs = [ ocaml ];
+  text = "${dune}/bin/dune build @fmt \"$@\"";
+}

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -82,6 +82,7 @@ in
   purty = callPackage ./purty { purty = nodePackages.purty; };
   terraform-fmt = callPackage ./terraform-fmt { };
   dune-build-opam-files = callPackage ./dune-build-opam-files { dune = dune_3; inherit (pkgsBuildBuild) ocaml; };
+  dune-fmt = callPackage ./dune-fmt { dune = dune_3; inherit (pkgsBuildBuild) ocaml; };
   latexindent = tex;
   chktex = tex;
   commitizen = commitizen.overrideAttrs (_: _: { doCheck = false; });


### PR DESCRIPTION
The `dune-fmt` hook runs `dune fmt` which relies on external programs (`ocamlformat`, `refmt` or any custom formatter as long as it's declared in `dune-project`) to run properly. I provide that via an `extraRuntimeInputs` option. Not sure at all whether this is the right way to do things, and I assume some other hooks (eg. Prettier) must have similar issues and possibly cleaner ways to resolve it.

Additionally, the `dune fmt` command always requires the presence of `ocamlc` in the system, so I take care of that too.