### PR TITLE
Fixup hook docs (doc fixup)

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -259,7 +259,7 @@ in
                 name = "my-tool";
                 description = "Run MyTool on all files in the project";
                 files = "\\.mtl$";
-                entry = "${pkgs.my-tool}/bin/mytoolctl";
+                entry = "''${pkgs.my-tool}/bin/mytoolctl";
               };
               ```
 


### PR DESCRIPTION
Accidentally forgot to escape the example in the description.