### PR TITLE
Add optional `hintFile` setting to hlint

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -45,6 +45,15 @@ in
               default = false;
             };
         };
+      hlint =
+        {
+          hintFile =
+            mkOption {
+              type = types.nullOr types.path;
+              description = lib.mdDoc "Path to hlint.yaml. By default, hlint searches for .hlint.yaml in the project root.";
+              default = null;
+            };
+        };
       ormolu =
         {
           defaultExtensions =
@@ -524,7 +533,7 @@ in
           name = "hlint";
           description =
             "HLint gives suggestions on how to improve your source code.";
-          entry = "${tools.hlint}/bin/hlint";
+          entry = "${tools.hlint}/bin/hlint${if settings.hlint.hintFile == null then "" else " --hint=${settings.hlint.hintFile}"}";
           files = "\\.l?hs(-boot)?$";
         };
       hpack =


### PR DESCRIPTION
By default, hlint searches for a .hlint.yaml hint file in the project root. Some projects may not want to put the hint file there, for which hlint provides a `--hint` flag.
This adds support for that.