### PR TITLE
fix(deadnix): fix typo in deadnix arguments

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -691,7 +691,7 @@ in
             let
               cmdArgs =
                 mkCmdArgs (with settings.deadnix; [
-                  [ noLambdaArg "--no-lamda-arg" ]
+                  [ noLambdaArg "--no-lambda-arg" ]
                   [ noLambdaPatternNames "--no-lambda-pattern-names" ]
                   [ noUnderscore "--no-underscore" ]
                   [ quiet "--quiet" ]


### PR DESCRIPTION
I mean, title is pretty self-explanatory. But for the sake of others looking for this problem in upcoming days with 23.05 release... Fixes this:

```
error: unexpected argument '--no-lamda-arg' found

  tip: a similar argument exists: '--no-lambda-arg'

Usage: deadnix --no-lambda-arg [FILE_PATHS]...
```
