### PR TITLE
nil: Fix hook only failing if last file fails

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -731,9 +731,20 @@ in
           entry =
             let
               script = pkgs.writeShellScript "precommit-nil" ''
+                errors=false
+                echo Checking: $@
                 for file in $(echo "$@"); do
                   ${tools.nil}/bin/nil diagnostics "$file"
+                  exit_code=$?
+
+                  if [[ $exit_code -ne 0 ]]; then
+                    echo \"$file\" failed with exit code: $exit_code
+                    errors=true
+                  fi
                 done
+                if [[ $errors == true ]]; then
+                  exit 1
+                fi
               '';
             in
             builtins.toString script;


### PR DESCRIPTION
As `set -e` is not set, the script only inherits the exit code of the last command which would be `nil diagnostics $file` on the last file in the array.

As `pre-commit` separates the files into separate batches and invokes the script multiple times, I think that it's better for the script to not exit early so that `nil` can be run on all the files.

Adding messaging on stdout is also useful for debugging, by default, it only appears when the hook fails, or when someone specifies `-v` to `pre-commit run`.

