### PR TITLE
Add workaround for when `core.hooksPath` is set

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -274,7 +274,7 @@ in
 
               ${
                 lib.concatStringsSep
-                  "\n" 
+                  "\n"
                   (lib.mapAttrsToList
                     (hookName: hookConf:
                       ''
@@ -429,6 +429,7 @@ in
                 for hook in $hooks; do
                   pre-commit uninstall -t $hook
                 done
+                ${git}/bin/git config --local core.hooksPath ""
                 # Add hooks for configured stages (only) ...
                 if [ ! -z "${concatStringsSep " " install_stages}" ]; then
                   for stage in ${concatStringsSep " " install_stages}; do
@@ -454,6 +455,7 @@ in
                 else
                   pre-commit install
                 fi
+                ${git}/bin/git config --local core.hooksPath "$(${git}/bin/git rev-parse --git-common-dir)/hooks"
               fi
             fi
           fi


### PR DESCRIPTION
This workaround allows the `pre-commit` hooks to be installed when `core.hooksPath` is set globally :+1: 