### PR TITLE
fix(lua-ls): correct typo + path to .luarc.json config

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -642,7 +642,7 @@ in
                 --logpath="$logpath"
               if [[ -f $logpath/check.json ]]; then
                 echo "+++++++++++++++ lua-language-server diagnostics +++++++++++++++"
-                cat $logdir/check.json
+                cat $logpath/check.json
                 exit 1
               fi
             '';

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -635,7 +635,7 @@ in
               set -e
               export logpath="$(mktemp -d)"
               # For some reason, lua-language-server hangs if the nix store path to the file is passed in directly
-              cp "${luarc}" .
+              cp "${luarc}" .luarc.json
               lua-language-server --check $(realpath .) \
                 --checklevel="${settings.lua-ls.checklevel}" \
                 --configpath=$(realpath .luarc.json) \


### PR DESCRIPTION
I had a typo tha prevents the diagnostic report from being printed if the lint fails.
It also turns out the name of the copied .luarc.json was not correct.

I have tested these fixes with: https://github.com/mrcjkb/neotest-haskell/pull/94, which uses a lua-ls config.