### PR TITLE
`dune-opam-sync` should also trigger on opam template files

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -570,7 +570,7 @@ in
         name = "dune/opam sync";
         description = "Check that Dune-generated OPAM files are in sync.";
         entry = "${tools.dune-build-opam-files}/bin/dune-build-opam-files";
-        files = "(\\.opam$)|((^|/)dune-project$)";
+        files = "(\\.opam$)|(\\.opam.template$)|((^|/)dune-project$)";
         ## We don't pass filenames because they can only be misleading. Indeed,
         ## we need to re-run `dune build` for every `*.opam` file, but also when
         ## the `dune-project` file has changed.


### PR DESCRIPTION
OPAM files are generated by Dune from `dune-project` **and `.opam.template` files** which I forgot to include in the first version of the hook.