### PR TITLE
maint: Don't use literalDocBook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v21
+    - uses: cachix/install-nix-action@v22
     - uses: cachix/cachix-action@v12
       with:
         name: pre-commit-hooks
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v21
+    - uses: cachix/install-nix-action@v22
     - uses: cachix/cachix-action@v12
       with:
         name: pre-commit-hooks

--- a/flake-module.nix
+++ b/flake-module.nix
@@ -36,7 +36,7 @@ in
                 Nixpkgs to use in the pre-commit [`settings`](#opt-perSystem.pre-commit.settings).
               '';
               default = pkgs;
-              defaultText = lib.literalDocBook "<literal>pkgs</literal> (module argument)";
+              defaultText = lib.literalMD "`pkgs` (module argument)";
             };
             settings = mkOption {
               type = types.submoduleWith {
@@ -52,7 +52,7 @@ in
               type = types.str;
               description = lib.mdDoc "A bash fragment that sets up [pre-commit](https://pre-commit.com/).";
               default = cfg.settings.installationScript;
-              defaultText = lib.literalDocBook "bash statements";
+              defaultText = lib.literalMD "bash statements";
               readOnly = true;
             };
             devShell = mkOption {

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -44,7 +44,7 @@ let
               mkOption {
                 type = types.str;
                 default = name;
-                defaultText = lib.literalDocBook or literalExample "internal name, same as id";
+                defaultText = lib.literalMD "internal name, same as `id`";
                 description = lib.mdDoc
                   ''
                     The name of the hook - shown during hook execution.


### PR DESCRIPTION
It uses `lib.literalMD` directly because backcompat is hardly an issue, as users generally won't have a custom doc rendering expression let alone having to use it with a pretty old Nixpkgs. `lib.whatever` passes Nix's eager scope checking just fine; that's only about direct variable references and not about attributes. So no need for ceremony in the form of a bunch of `or`.