### PR TITLE
fix(tflint): Fix warning running tflint

### DIFF
--- a/nix/tflint/default.nix
+++ b/nix/tflint/default.nix
@@ -1,0 +1,10 @@
+{ lib, writeScriptBin, tflint }:
+
+if lib.versionAtLeast tflint.version "0.45.0"
+then
+  (writeScriptBin "tflint" ''
+    #!/usr/bin/env bash
+    ${tflint}/bin/tflint --chdir "$(dirname $1)" --filter "$(basename $1)"
+  '')
+else
+  tflint

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -109,7 +109,6 @@ in
     stylish-haskell
     stylua
     tagref
-    tflint
     topiary
     typos
     yamllint
@@ -127,6 +126,7 @@ in
   hunspell = callPackage ./hunspell { };
   purty = callPackage ./purty { purty = nodePackages.purty; };
   terraform-fmt = callPackage ./terraform-fmt { };
+  tflint = callPackage ./tflint { };
   dune-build-opam-files = callPackage ./dune-build-opam-files { dune = dune_3; inherit (pkgsBuildBuild) ocaml; };
   dune-fmt = callPackage ./dune-fmt { dune = dune_3; inherit (pkgsBuildBuild) ocaml; };
   latexindent = tex;


### PR DESCRIPTION
Beginning with [0.45.0](https://github.com/terraform-linters/tflint/blob/master/CHANGELOG.md#0450-2023-02-13), tflint prefers the syntax `tflint —-chdir path/to —-filter file.tf` over passing the entire path to the command like `tflint path/to/file.tf`. While the old syntax is still functional, it generates the following warning during execution:

```
WARNING: "tflint FILE/DIR" is deprecated and will error in a future version. Use --chdir or --filter instead.
```