### PR TITLE
Revert "bump fourmolu, 0.9 -> 0.12"

### DIFF
--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -115,7 +115,7 @@ in
     ;
   inherit (elmPackages) elm-format elm-review elm-test;
   # TODO: these two should be statically compiled
-  fourmolu = haskellPackages.fourmolu_0_12_0_0;
+  inherit (haskellPackages) fourmolu;
   inherit (luaPackages) luacheck;
   inherit (nodePackages) eslint markdownlint-cli prettier cspell;
   inherit (ocamlPackages) ocp-indent;


### PR DESCRIPTION
This reverts commit e04dd8f275dcdd8ae7a895cd884aa5cc186f82d5.

It created problems because:

    It breaks caching when just used with cache.nixos.org
    It leads to inconsistent formatting between the pre-commit hook and fourmolu installed from shell.
    It tightly couples this repo to a nixpkgs commit. When used together with current nixos-unstable it throws an eval error.

See the discussion in #312
