### PR TITLE
hooks.nix: string -> str

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -486,7 +486,7 @@ in
       headache =
         {
           header-file = mkOption {
-            type = types.string;
+            type = types.str;
             description = lib.mdDoc "Path to the header file.";
             default = ".header";
           };


### PR DESCRIPTION
Fix a warning.

legacy string type is still giving us a headache...