### PR TITLE
Do not print "hooks up to date" message

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -408,10 +408,8 @@ in
             # filesystem churn. This improves performance with watch tools like lorri
             # and prevents installation loops by via lorri.
 
-            if readlink "''${GIT_WC}/.pre-commit-config.yaml" >/dev/null \
-              && [[ $(readlink "''${GIT_WC}/.pre-commit-config.yaml") == ${configFile} ]]; then
-              echo 1>&2 "pre-commit-hooks.nix: hooks up to date"
-            else
+            if ! readlink "''${GIT_WC}/.pre-commit-config.yaml" >/dev/null \
+              || [[ $(readlink "''${GIT_WC}/.pre-commit-config.yaml") != ${configFile} ]]; then
               echo 1>&2 "pre-commit-hooks.nix: updating $PWD repo"
 
               [ -L .pre-commit-config.yaml ] && unlink .pre-commit-config.yaml


### PR DESCRIPTION
When using standard flake direnv integration (i.e. `use flake` in `.envrc`), the "hooks up to date" informational message currently prints before every prompt. This feels unnecessarily verbose.

One workaround is to perform stderr filtering within `.envrc`, replacing `use flake` with `use flake 2> >(grep -v 'hooks up to date' >&2)`. Including that sort of logic in `.envrc` feels like a bit of an antipattern. In extreme cases it could also fail if `grep` is not available outside of the nix devshell.