### PR TITLE
Only run `typos` against text files by default

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1057,6 +1057,7 @@ in
           description = "Source code spell checker";
           entry = with settings.typos;
             "${tools.typos}/bin/typos --format ${format} ${lib.optionalString write "-w"} ${lib.optionalString diff "--diff"}";
+          types = [ "text" ];
         };
 
       cspell =


### PR DESCRIPTION
By default, `typos` currently attempts to run against non-textual files (e.g. PNGs). Doing so lmost always results in spurious errors.