### PR TITLE
Add yamllint to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,10 @@ use nix
 - `terraform-format`: built-in formatter
 - [tflint](https://github.com/terraform-linters/tflint)
 
+## YAML
+
+- [yamllint](https://github.com/adrienverge/yamllint)
+
 ## TOML
 
 - [taplo fmt](https://github.com/tamasfe/taplo)


### PR DESCRIPTION
I noticed `yamllint` was missing from the README, although it is included. So I added a section for YAML.