### PR TITLE
Fix docs and check docs in flake check

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -266,6 +266,7 @@ in
               type = types.path;
               description = lib.mdDoc "`rome` binary path. E.g. if you want to use the `rome` in `node_modules`, use `./node_modules/.bin/rome`.";
               default = "${pkgs.rome}/bin/rome";
+              defaultText = "\${pkgs.rome}/bin/rome";
             };
 
           write =


### PR DESCRIPTION
This fixes the use of a package value in the docs, which would be rendered as a store path, which is inaccurate.

It also adds a check to make sure that this mistake is caught.

The code is based on what flake.parts-website uses for doc rendering.

Alternative solutions would be either
 - `nix build github:hercules-ci/flake.parts-website --override-input pre-commit-hooks-nix .`, which would slow down the CI a bit, or
 - allow some use of `pkgs` attributes, but this is not a scalable solution, as explained in the second commit message.
