### PR TITLE
Fix settings and add config option for `typos` hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -294,6 +294,30 @@ in
               default = "auto";
             };
 
+          config =
+            mkOption {
+              type = types.str;
+              description = lib.mdDoc "Multiline-string configuration passed as config file.";
+              default = "";
+              example = ''
+                [files]
+                ignore-dot = true
+
+                [default]
+                binary = false
+
+                [type.py]
+                extend-glob = []
+              '';
+            };
+
+          configPath =
+            mkOption {
+              type = types.str;
+              description = lib.mdDoc "Path to a custom config file.";
+              default = "";
+            };
+
           diff =
             mkOption {
               type = types.bool;
@@ -333,7 +357,7 @@ in
           write =
             mkOption {
               type = types.bool;
-              description = lib.mdDoc "Whether to write fixes out.";
+              description = lib.mdDoc "Whether to fix spelling in files by writing them. Cannot be used with `typos.settings.diff`.";
               default = false;
             };
         };
@@ -1224,8 +1248,22 @@ in
         {
           name = "typos";
           description = "Source code spell checker";
-          entry = with settings.typos;
-            "${tools.typos}/bin/typos --color ${color} ${lib.optionalString diff "--diff"} --exclude ${exclude} --format ${format} {lib.optionalString hidden " - -hidden "} --locale ${locale} ${lib.optionalString write "-write-changes"}";
+          entry =
+            let
+              configFile = builtins.toFile "config.toml" "${settings.typos.config}";
+              cmdArgs =
+                mkCmdArgs
+                  (with settings.typos; [
+                    [ (color != "") "--color ${color}" ]
+                    [ (configPath != "") "--config ${configPath}" ]
+                    [ (config != "" && configPath == "") "--config ${configFile}" ]
+                    [ (exclude != "") "--exclude ${exclude}" ]
+                    [ (format != "") "--format ${format}" ]
+                    [ (locale != "") "--locale ${locale}" ]
+                    [ (write && !diff) "--write-changes" ]
+                  ]);
+            in
+            "${tools.typos}/bin/typos ${cmdArgs}${lib.optionalString settings.typos.diff " --diff"}${lib.optionalString settings.typos.hidden " --hidden"}";
           types = [ "text" ];
         };
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -25,14 +25,14 @@ in
         {
           configPath = mkOption {
             type = types.str;
-            description = "path to the configuration YAML file";
+            description = lib.mdDoc "Path to the YAML configuration file.";
             # an empty string translates to use default configuration of the
             # underlying ansible-lint binary
             default = "";
           };
           subdir = mkOption {
             type = types.str;
-            description = "path to Ansible subdir";
+            description = lib.mdDoc "Path to the Ansible subdirectory.";
             default = "";
           };
         };
@@ -278,12 +278,13 @@ in
 
           configPath = mkOption {
             type = types.str;
-            description = "path to the configuration JSON file";
+            description = lib.mdDoc "Path to the configuration JSON file";
             # an empty string translates to use default configuration of the
             # underlying rome binary (i.e rome.json if exists)
             default = "";
           };
         };
+
       typos =
         {
           color =
@@ -495,13 +496,13 @@ in
         {
           relaxed = mkOption {
             type = types.bool;
-            description = lib.mdDoc "Use the relaxed configuration";
+            description = lib.mdDoc "Whether to use the relaxed configuration.";
             default = false;
           };
 
           configPath = mkOption {
             type = types.str;
-            description = "path to the configuration YAML file";
+            description = lib.mdDoc "Path to the YAML configuration file.";
             # an empty string translates to use default configuration of the
             # underlying yamllint binary
             default = "";


### PR DESCRIPTION
I fixed what I broke earlier, when I introduced new options for the `typos` hook :sweat_smile:
I also added a `config` and `configPath` option. With the `config` option it becomes possilble to pass the configuration right from the `devenv` configuration. This should fix #291.

This time I tested all the settings in a newly created project to make sure everything works as expected.

Additionally, I changed the wording for some settings to make the references more consistent.