### PR TITLE
Added skipBinCopy option for prettier and eslint

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1194,6 +1194,7 @@ in
           name = "prettier";
           description = "Opinionated multi-language code formatter.";
           entry = with settings.prettier;
+            # Casting `binPath` to a string will prevent the path from being copied to the nix store.
             "${if skipBinCopy then toString binPath else binPath} ${lib.optionalString write "--write"} ${lib.optionalString (output != null) "--${output}"} --ignore-unknown";
           types = [ "text" ];
         };
@@ -1289,6 +1290,7 @@ in
           name = "eslint";
           description = "Find and fix problems in your JavaScript code.";
           entry = with settings.eslint;
+            # Casting `binPath` to a string will prevent the path from being copied to the nix store.
             "${if skipBinCopy then toString eslint.binPath else binPath} --fix";
           files = "${settings.eslint.extensions}";
         };

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -219,11 +219,19 @@ in
             mkOption {
               type = types.path;
               description = lib.mdDoc
-                "`prettier` binary path. E.g. if you want to use the `prettier` in `node_modules`, use `./node_modules/.bin/prettier`.";
+                "`prettier` binary path. E.g. if you want to use the `prettier` in `node_modules`, use `./node_modules/.bin/prettier` and enable `skipBinCopy`.";
               default = "${tools.prettier}/bin/prettier";
               defaultText = lib.literalExpression ''
                 "''${tools.prettier}/bin/prettier"
               '';
+            };
+
+          skipBinCopy =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc
+                "If set, prevents the binary from being copied to the nix store. This should only be set if the binary is already committed to your repo.";
+              default = false;
             };
 
           write =
@@ -246,9 +254,17 @@ in
             mkOption {
               type = types.path;
               description = lib.mdDoc
-                "`eslint` binary path. E.g. if you want to use the `eslint` in `node_modules`, use `./node_modules/.bin/eslint`.";
+                "`eslint` binary path. E.g. if you want to use the `eslint` in `node_modules`, use `./node_modules/.bin/eslint` and enable `skipBinCopy`.";
               default = "${tools.eslint}/bin/eslint";
               defaultText = lib.literalExpression "\${tools.eslint}/bin/eslint";
+            };
+
+          skipBinCopy =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc
+                "If set, prevents the binary from being copied to the nix store. This should only be set if the binary is already committed to your repo.";
+              default = false;
             };
 
           extensions =
@@ -1178,7 +1194,7 @@ in
           name = "prettier";
           description = "Opinionated multi-language code formatter.";
           entry = with settings.prettier;
-            "${binPath} ${lib.optionalString write "--write"} ${lib.optionalString (output != null) "--${output}"} --ignore-unknown";
+            "${if skipBinCopy then toString binPath else binPath} ${lib.optionalString write "--write"} ${lib.optionalString (output != null) "--${output}"} --ignore-unknown";
           types = [ "text" ];
         };
       pre-commit-hook-ensure-sops = {
@@ -1272,7 +1288,8 @@ in
         {
           name = "eslint";
           description = "Find and fix problems in your JavaScript code.";
-          entry = "${settings.eslint.binPath} --fix";
+          entry = with settings.eslint;
+            "${if skipBinCopy then toString eslint.binPath else binPath} --fix";
           files = "${settings.eslint.extensions}";
         };
 


### PR DESCRIPTION
This makes it so that the logic agrees with the docs: https://devenv.sh/reference/options/#pre-commitsettingsprettierbinpath . If you disagree with the spirit of this change then I think at the least the documentation should be updated because what it suggests today doesn't work.

Relevant issue is #336 , I've added a branch named `with-patched-pre-commit-hooks-nix` to the repo I used to reproduce the issue and it seems to work. Relevant change in the repo: https://github.com/alejandro-angulo/devenv-pre-commit-test/compare/main...with-patched-pre-commit-hooks-nix .

This is basically the same as what I suggested in the issue earlier but I decided to name the option `skipBinCopy` rather than `binPathInRepo`.