### PR TITLE
Let shellcheck handle good vs bad shell types

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1055,16 +1055,6 @@ in
           name = "shellcheck";
           description = "Format shell files.";
           types = [ "shell" ];
-          types_or =
-            # based on `goodShells` in https://github.com/koalaman/shellcheck/blob/master/src/ShellCheck/Parser.hs
-            [
-              "sh"
-              "ash"
-              "bash"
-              "bats"
-              "dash"
-              "ksh"
-            ];
           entry = "${tools.shellcheck}/bin/shellcheck";
         };
       bats =


### PR DESCRIPTION
This matches official shellcheck pre-commit hook[1]. This works because shellcheck will silently skip "badShells" so there isn't a good reason to do this here. The old setup was actually causing pre-commit to skip shell scripts ending with .sh since both `types` *and* `types_or` were specified but the identified tags resulted in an empty set since `shell` is not in `types_or`, nor is `sh` returned from identification:

```shell-session
$ cat t.sh

echo hi
$ nix-shell -p python3Packages.identify --run 'identify-cli t.sh'
["file", "non-executable", "shell", "text"]
```

An argument could be had that 'sh' should have shown up due to the extension similar to other shells but I still believe we should merge this and match upstream.

[1]: https://github.com/koalaman/shellcheck-precommit/blob/v0.9.0/.pre-commit-hooks.yaml#L7