### PR TITLE
Add profile setting to isort hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -598,8 +598,15 @@ in
               description = lib.mdDoc "mkdocs-linkcheck binary path. Should be used to specify the mkdocs-linkcheck binary from your Nix-managed Python environment.";
               default = "${pkgs.python311Packages.mkdocs-linkcheck}/bin/mkdocs-linkcheck";
               defaultText = lib.literalExpression ''
-                "''${pkgs.mkdocs-linkcheck}/bin/mkdocs-linkcheck"
+                "''${pkgs.python311Packages.mkdocs-linkcheck}/bin/mkdocs-linkcheck"
               '';
+            };
+
+          path =
+            mkOption {
+              type = types.str;
+              description = lib.mdDoc "Path to check";
+              default = "";
             };
 
           local-only =
@@ -1629,12 +1636,15 @@ in
             cmdArgs =
               mkCmdArgs
                 (with settings.mkdocs-linkcheck; [
-                  [ (extension != "") "--ext ${extension}" ]
-                  [ (method != "") "--method ${method}" ]
+                  [ local-only " --local" ]
+                  [ recurse " --recurse" ]
+                  [ (extension != "") " --ext ${extension}" ]
+                  [ (method != "") " --method ${method}" ]
+                  [ (path != "") " ${path}" ]
                 ]);
           in
-          "${settings.mkdocs-linkcheck.binPath} ${cmdArgs}${lib.optionalString settings.mkdocs-linkcheck.local-only " --local"}${lib.optionalString settings.mkdocs-linkcheck.recurse " --recurse"}";
-        types = [ "text" ];
+          "${settings.mkdocs-linkcheck.binPath}${cmdArgs}";
+        types = [ "text" "markdown" ];
       };
 
       checkmake = {

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -54,6 +54,15 @@ in
               default = null;
             };
         };
+      isort =
+        {
+          profile =
+            mkOption {
+              type = types.enum [ "" "black" "django" "pycharm" "google" "open_stack" "plone" "attrs" "hug" "wemake" "appnexus" ];
+              description = lib.mdDoc "Built-in profiles to allow easy interoperability with common projects and code styles.";
+              default = "";
+            };
+        };
       ormolu =
         {
           defaultExtensions =
@@ -805,8 +814,16 @@ in
         {
           name = "isort";
           description = "A Python utility / library to sort imports.";
-          entry = "${pkgs.python3Packages.isort}/bin/isort";
           types = [ "file" "python" ];
+          entry =
+            let
+              cmdArgs =
+                mkCmdArgs
+                  (with settings.isort; [
+                    [ (profile != "") " --profile ${profile}" ]
+                  ]);
+            in
+            "${pkgs.python3Packages.isort}/bin/isort${cmdArgs}";
         };
       latexindent =
         {


### PR DESCRIPTION
I added the profile setting to the isort hook. I plan to add some other later if I find the time. There are a lot of CLI options for isort, so I have to check which ones make sense and which can just be passed as flags.

I also noticed that mkdocs-linkcheck hook was still not quite right, as enabling it, without declaring any settings, caused devenv to fail building the devShell. I fixed that now