### PR TITLE
fix(stylua): don't pass in files so it picks up .styluaignore

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1095,6 +1095,8 @@ in
           description = "An Opinionated Lua Code Formatter.";
           types = [ "file" "lua" ];
           entry = "${tools.stylua}/bin/stylua";
+          # stylua does not pick up .styluaignore if we pass in the file names.
+          pass_filenames = false;
         };
       shfmt =
         {


### PR DESCRIPTION
When passing in the file name to `stylua`, it bypasses [`.styluaignore`](https://github.com/JohnnyMorganz/StyLua#filtering-using-styluaignore).

See also: https://github.com/JohnnyMorganz/StyLua/issues/751