### PR TITLE
Add alejandra verbosity settings

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -971,7 +971,7 @@ in
             let
               cmdArgs =
                 mkCmdArgs (with settings.alejandra; [
-                  [ (quiet && !slient) "--quiet" ]
+                  [ (quiet && !silent) "--quiet" ]
                   [ silent "--quiet --quiet" ]
                   [ (exclude != [ ]) "--exclude ${lib.escapeShellArgs (lib.unique exclude)}" ]
                 ]);

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -87,6 +87,18 @@ in
               default = [ ];
               example = [ "flake.nix" "./templates" ];
             };
+          quiet =
+            mkOption {
+              type = types.bool;
+              description = "Hide informational messages. Redundant if used with `silent`.";
+              default = false;
+            };
+          silent =
+            mkOption {
+              type = types.bool;
+              description = "Hide error messages and informational messages. Implies `quiet`.";
+              default = false;
+            };
         };
       deadnix =
         {
@@ -955,8 +967,16 @@ in
         {
           name = "alejandra";
           description = "The Uncompromising Nix Code Formatter.";
-          entry = with settings.alejandra;
-            "${tools.alejandra}/bin/alejandra ${if (exclude != [ ]) then "-e ${lib.escapeShellArgs (lib.unique exclude)}" else ""}";
+          entry =
+            let
+              cmdArgs =
+                mkCmdArgs (with settings.alejandra; [
+                  [ (quiet && !slient) "--quiet" ]
+                  [ silent "--quiet --quiet" ]
+                  [ (exclude != [ ]) "--exclude ${lib.escapeShellArgs (lib.unique exclude)}" ]
+                ]);
+            in
+            "${tools.alejandra}/bin/alejandra ${cmdArgs}";
           files = "\\.nix$";
         };
 


### PR DESCRIPTION
Hello,
This PR adds two settings to `alejandra` that control verbosity flags.
- quiet (bool): maps to `alejandra --quiet`
- silent (bool): maps to `alejandra --quiet --quiet`. While it look strange, the double argument is intentional. It makes a little more sense with the short format, `-qq`, but I spelled out the long version for better readability.

The `quiet` option is redundant when `silent` is set. An enum with normal/quiet/silent options would have been ideal here. I'm still learning the nix language and couldn't come up with a better way to do this. If you have any thoughts, let me know!