### PR TITLE
Add hook for vale (linter for prose)

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -688,6 +688,34 @@ in
             default = true;
           };
       };
+
+      vale = {
+        config =
+          mkOption {
+            type = types.str;
+            description = lib.mdDoc "Multiline-string configuration passed as config file.";
+            default = "";
+            example = ''
+              MinAlertLevel = suggestion
+              [*]
+              BasedOnStyles = Vale
+            '';
+          };
+
+        configPath =
+          mkOption {
+            type = types.str;
+            description = lib.mdDoc "Path to the config file.";
+            default = "";
+          };
+
+        flags =
+          mkOption {
+            type = types.str;
+            description = lib.mdDoc "Flags passed to vale.";
+            default = "";
+          };
+      };
     };
 
   config.hooks =
@@ -1736,6 +1764,23 @@ in
           let strict = if settings.credo.strict then "--strict" else "";
           in "${pkgs.elixir}/bin/mix credo";
         types = [ "elixir" ];
+      };
+
+      vale = {
+        name = "vale";
+        description = "A markup-aware linter for prose built with speed and extensibility in mind.";
+        entry =
+          let
+            configFile = builtins.toFile ".vale.ini" "${settings.vale.config}";
+            cmdArgs =
+              mkCmdArgs
+                (with settings.vale; [
+                  [ (configPath != "") " --config ${configPath}" ]
+                  [ (config != "" && configPath == "") " --config ${configFile}" ]
+                ]);
+          in
+          "${pkgs.vale}/bin/vale${cmdArgs} ${settings.vale.flags}";
+        types = [ "text" ];
       };
 
       dialyzer = {


### PR DESCRIPTION
This adds a new hook for [vale](https://github.com/errata-ai/vale), which was requested in #46.

According to the repos description, vale is a markup-aware linter for prose built with speed and extensibility in mind. 

Like for the typo hook, it is possible to pass a multi-line configuration using the `config` setting or the path to a local configuration file by using the `configPath` setting.
All other arguments can be passed using the `flags` setting.