### PR TITLE
Fix broken import (eclint)

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -304,13 +304,13 @@ in
         };
       eclint =
         {
-          binPath =
+          package =
             mkOption {
-              type = types.path;
-              description = lib.mdDoc
-                "EditorConfig linter and formatter.";
-              default = "${tools.eclint}/bin/eclint";
-              defaultText = lib.literalExpression "\${tools.eclint}/bin/eclint";
+              type = types.package;
+              description = lib.mdDoc "The `eclint` package to use.";
+              default = "${tools.eclint}";
+              defaultText = "\${tools.eclint}";
+              example = "\${pkgs.eclint}";
             };
         };
       rome =
@@ -1499,8 +1499,8 @@ in
       eclint =
         {
           name = "eclint";
-          description = "Find and fix problems according to .editorconfig.";
-          entry = "${settings.eclint.binPath} --fix";
+          description = "EditorConfig linter written in Go.";
+          entry = "${settings.eclint.package}/bin/eclint --fix";
         };
 
       rome =

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -17,6 +17,7 @@
 , deno
 , dhall
 , dune_3
+, eclint
 , editorconfig-checker
 , elmPackages
 , fprettify
@@ -87,6 +88,7 @@ in
     deadnix
     deno
     dhall
+    eclint
     editorconfig-checker
     fprettify
     go
@@ -121,7 +123,7 @@ in
   # TODO: these two should be statically compiled
   inherit (haskellPackages) fourmolu;
   inherit (luaPackages) luacheck;
-  inherit (nodePackages) eslint markdownlint-cli prettier cspell eclint;
+  inherit (nodePackages) eslint markdownlint-cli prettier cspell;
   inherit (ocamlPackages) ocp-indent;
   lua-language-server = lua-language-server;
   purs-tidy = nodePackages.purs-tidy or null;


### PR DESCRIPTION
The merge of PR #359 caused pipelines to fail as master is now broken due to a missing import.

Since the import is not strictly needed, I'd say it is better to remove it again.

Also, notice that `eclint` in nixpkgs is not the [archived eclint](https://github.com/jednano/eclint) written in JS, but a [maintained alternative also named eclint](https://gitlab.com/greut/eclint) written in Go. Thus, if listing it in `nix/tools.nix` it does not belong in `nodePackages`.