### PR TITLE
Switch type to one supported by precommit

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1238,14 +1238,14 @@ in
         name = "mix-format";
         descriptiion = "Runs the built-in Elixir syntax formatter";
         entry = "${pkgs.elixir}/bin/mix format";
-        types = [ "elixir" ];
+        types = [ "file" ];
       };
 
       mix-test = {
         name = "mix-test";
         descriptiion = "Runs the built-in Elixir test framework";
         entry = "${pkgs.elixir}/bin/mix test";
-        types = [ "elixir" ];
+        types = [ "file" ];
       };
 
       credo = {
@@ -1254,14 +1254,14 @@ in
         entry =
           let strict = if settings.credo.strict then "--strict" else "";
           in "${pkgs.elixir}/bin/mix credo";
-        types = [ "elixir" ];
+        types = [ "file" ];
       };
 
       dialyzer = {
         name = "dialyzer";
         descriptiion = "Runs a static code analysis using Dialyzer";
         entry = "${pkgs.elixir}/bin/mix dialyzer";
-        types = [ "elixir" ];
+        types = [ "file" ];
       };
     };
 }


### PR DESCRIPTION
Even though python `identify` registers these with a tag of `elixir`, it looks like `precommit` only supports some tags as types.  This change converts these to supported types.