### PR TITLE
Specify files attribute for Elixir programs

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2129,14 +2129,14 @@ in
         name = "mix-format";
         description = "Runs the built-in Elixir syntax formatter";
         entry = "${pkgs.elixir}/bin/mix format";
-        types = [ "file" ];
+        files = "\\.exs?$";
       };
 
       mix-test = {
         name = "mix-test";
         description = "Runs the built-in Elixir test framework";
         entry = "${pkgs.elixir}/bin/mix test";
-        types = [ "file" ];
+        files = "\\.exs?$";
       };
 
       credo = {
@@ -2145,7 +2145,7 @@ in
         entry =
           let strict = if settings.credo.strict then "--strict" else "";
           in "${pkgs.elixir}/bin/mix credo";
-        types = [ "file" ];
+        files = "\\.exs?$";
       };
 
       vale = {
@@ -2169,7 +2169,7 @@ in
         name = "dialyzer";
         description = "Runs a static code analysis using Dialyzer";
         entry = "${pkgs.elixir}/bin/mix dialyzer";
-        types = [ "file" ];
+        files = "\\.exs?$";
       };
 
       crystal = {


### PR DESCRIPTION
After #364, the Elixir hooks run on other syntax's too (e.g. Nix), which is not an expected behavior. `elixir` type will be supported on stable soon, but this PR resolves the issue for now.

The regular expression is based on this commit: https://github.com/pre-commit/identify/commit/3b0128c58d4b401f1a937cb79fadc2e2594f9ce7