### PR TITLE
Add git-annex pre-commit hook

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Use 4 spaces for the Python files
+[*.py]
+indent_size = 4
+max_line_length = 80
+
+# The JSON files contain newlines inconsistently
+[*.json]
+insert_final_newline = ignore
+
+# Minified JavaScript files shouldn't be changed
+[**.min.js]
+indent_style = ignore
+insert_final_newline = ignore
+
+# Makefiles always use tabs for indentation
+[Makefile]
+indent_style = tab
+
+# Batch files use tabs for indentation
+[*.bat]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false
+

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ clang-format = {
 - [commitizen](https://github.com/commitizen-tools/commitizen)
 - [gptcommit](https://github.com/zurawiki/gptcommit)
 - [convco](https://github.com/convco/convco)
+- [annex](https://git-annex.branchable.com/)
 
 ## Custom hooks
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2202,5 +2202,11 @@ in
           "${pkgs.lychee}/bin/lychee${cmdArgs} ${settings.lychee.flags}";
         types = [ "text" ];
       };
+
+      annex = {
+        name = "annex";
+        description = "Runs the git-annex hook for large file support";
+        entry = "${tools.git-annex}/bin/git-annex pre-commit";
+      };
     };
 }

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -22,6 +22,7 @@
 , elmPackages
 , fprettify
 , git
+, git-annex
 , gitAndTools
 , gptcommit ? null
 , hadolint
@@ -94,6 +95,7 @@ in
     eclint
     editorconfig-checker
     fprettify
+    git-annex
     go
     go-tools
     gptcommit


### PR DESCRIPTION
Adds git-annex pre-commit hook which is required, when you want to use git-annex in a repository.
git-annex adds large file support and automatic sync to git