### PR TITLE
Fix hooksPath when configured from a subdirectory

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -465,7 +465,14 @@ in
                 else
                   pre-commit install
                 fi
-                ${git}/bin/git config --local core.hooksPath "$(${git}/bin/git rev-parse --git-common-dir)/hooks"
+
+                # Fetch the absolute path to the git common directory. This will normally point to $GIT_WC/.git.
+                common_dir=''$(${git}/bin/git rev-parse --path-format=absolute --git-common-dir)
+
+                # Convert the absolute path to a path relative to the toplevel working directory.
+                common_dir=''${common_dir#''$GIT_WC/}
+
+                ${git}/bin/git config --local core.hooksPath "''$common_dir/hooks"
               fi
             fi
           fi


### PR DESCRIPTION
Resolves #358.

N.B

This is a super rare edge-case, but I've noticed that `git rev-parse --toplevel` returns the wrong path if `$GIT_DIR` is set without also setting `$GIT_WORK_TREE`. When run from a subdirectory, it'll return the path to the current directory, instead of the toplevel one. Seems like a bug in `git`.