### PR TITLE
fix(stylua): add --respect-ignores flag

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -56,11 +56,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689261696,
-        "narHash": "sha256-LzfUtFs9MQRvIoQ3MfgSuipBVMXslMPH/vZ+nM40LkA=",
+        "lastModified": 1704842529,
+        "narHash": "sha256-OTeQA+F8d/Evad33JMfuXC89VMetQbsU4qcaePchGr4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "df1eee2aa65052a18121ed4971081576b25d6b5c",
+        "rev": "eabe8d3eface69f5bb16c18f8662a702f50c20d5",
         "type": "github"
       },
       "original": {

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2065,7 +2065,7 @@ in
           name = "stylua";
           description = "An Opinionated Lua Code Formatter.";
           types = [ "file" "lua" ];
-          entry = "${tools.stylua}/bin/stylua";
+          entry = "${tools.stylua}/bin/stylua --respect-ignores";
         };
       tagref =
         {


### PR DESCRIPTION
Stylua 0.19 [adds support](https://github.com/JohnnyMorganz/StyLua/pull/765) for a `--respect-ignores` flag, fixing an issue in which `.styluaignore` files were linted.

This is a follow-up on #346, which I closed in favour of this.

Note: Stylua 0.19 is not available in nixpkgs 23.05.