### PR TITLE
fix(modules/hooks): `settings.typos.exclude` implies `--force-exclude`

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1617,7 +1617,7 @@ in
                     [ (color != "") "--color ${color}" ]
                     [ (configPath != "") "--config ${configPath}" ]
                     [ (config != "" && configPath == "") "--config ${configFile}" ]
-                    [ (exclude != "") "--exclude ${exclude}" ]
+                    [ (exclude != "") "--exclude ${exclude} --force-exclude" ]
                     [ (format != "") "--format ${format}" ]
                     [ (locale != "") "--locale ${locale}" ]
                     [ (write && !diff) "--write-changes" ]


### PR DESCRIPTION
The `settings.typos.exclude` should imply the `--force-exclude` option in order to "Respect excluded files even for paths passed explicitly".

Follows:

- https://github.com/cachix/pre-commit-hooks.nix/pull/332
- https://github.com/crate-ci/typos/commit/8314a1567d03ff2b2b2e294c8bb63a4edcdf106a
