### PR TITLE
Add missing configs for json

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -132,6 +132,7 @@ let
               description = lib.mdDoc ''
                 if true this hook will execute using a single process instead of in parallel.
               '';
+              default = false;
             };
             stages =
               mkOption {
@@ -161,7 +162,7 @@ let
           {
             raw =
               {
-                inherit (config) name entry language files types types_or pass_filenames fail_fast stages verbose always_run;
+                inherit (config) name entry language files types types_or pass_filenames fail_fast require_serial stages verbose always_run;
                 id = name;
                 exclude = mergeExcludes config.excludes;
               };

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -125,6 +125,7 @@ let
               description = lib.mdDoc ''
                 if true pre-commit will stop running hooks if this hook fails.
               '';
+              default = false;
             };
             require_serial = mkOption {
               type = types.bool;
@@ -160,7 +161,7 @@ let
           {
             raw =
               {
-                inherit (config) name entry language files types types_or pass_filenames stages verbose always_run;
+                inherit (config) name entry language files types types_or pass_filenames fail_fast stages verbose always_run;
                 id = name;
                 exclude = mergeExcludes config.excludes;
               };

--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -160,7 +160,7 @@ let
           {
             raw =
               {
-                inherit (config) name entry language files stages types types_or pass_filenames verbose always_run;
+                inherit (config) name entry language files types types_or pass_filenames stages verbose always_run;
                 id = name;
                 exclude = mergeExcludes config.excludes;
               };


### PR DESCRIPTION
I tried to enable the `golangci-lint` hook and it failed due to running multiple golangci-lint binaries in parallel. So I came here and noticed that `require_serial = true;` was already being set and noticed that both it and `fail_fast` were not being populated into the .pre-commit-config.yaml file.