### PR TITLE
typos: unset pass_filenames

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -892,6 +892,7 @@ in
               type = types.str;
               description = lib.mdDoc "Path to a custom config file.";
               default = "";
+              example = ".typos.toml";
             };
 
           diff =
@@ -2153,6 +2154,11 @@ in
             in
             "${tools.typos}/bin/typos ${cmdArgs}${lib.optionalString settings.typos.diff " --diff"}${lib.optionalString settings.typos.hidden " --hidden"}";
           types = [ "text" ];
+          # Typos is supposed to run on the whole tree. If this is set to true,
+          # the system gets stuck for large projects due to very high memory
+          # consumption. The restriction on with files typos run, should be
+          # specified in the typos config file.
+          pass_filenames = false;
         };
       typstfmt = {
         name = "typstfmt";


### PR DESCRIPTION
Typos is supposed to run on the whole tree. If this is set to true, the system gets stuck for large projects due to very high memory consumption. The restriction on with files typos run, should be specified in the typos config file.


Tested this locally with a large project.