### PR TITLE
Extend options for `typos` hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1087,17 +1087,22 @@ in
         };
       typos =
         {
+          binary =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Whether to search binary files.";
+              default = false;
+            };
           color =
             mkOption {
               type = types.enum [ "auto" "always" "never" ];
               description = lib.mdDoc "When to use generate output.";
               default = "auto";
             };
-
           config =
             mkOption {
               type = types.str;
-              description = lib.mdDoc "Multiline-string configuration passed as config file.";
+              description = lib.mdDoc "Multiline-string configuration passed as config file. If set, config set in `typos.settings.configPath` gets ignored.";
               default = "";
               example = ''
                 [files]
@@ -1110,7 +1115,6 @@ in
                 extend-glob = []
               '';
             };
-
           configPath =
             mkOption {
               type = types.str;
@@ -1118,47 +1122,71 @@ in
               default = "";
               example = ".typos.toml";
             };
-
           diff =
             mkOption {
               type = types.bool;
-              description = lib.mdDoc "Whether to print a diff of what would change.";
+              description = lib.mdDoc "Print a diff of what would change.";
               default = false;
             };
-
           exclude =
             mkOption {
               type = types.str;
-              description = lib.mdDoc "Which files & directories to exclude matching the glob.";
+              description = lib.mdDoc "Ignore files and directories matching the glob.";
               default = "";
               example = "*.nix";
             };
-
           format =
             mkOption {
               type = types.enum [ "silent" "brief" "long" "json" ];
-              description = lib.mdDoc "Which output format to use.";
+              description = lib.mdDoc "Output format to use.";
               default = "long";
             };
-
           hidden =
             mkOption {
               type = types.bool;
-              description = lib.mdDoc "Whether to search hidden files and directories.";
+              description = lib.mdDoc "Search hidden files and directories.";
               default = false;
             };
-
           locale =
             mkOption {
               type = types.enum [ "en" "en-us" "en-gb" "en-ca" "en-au" ];
               description = lib.mdDoc "Which language to use for spell checking.";
               default = "en";
             };
-
+          no-check-filenames =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Skip verifying spelling in file names.";
+              default = false;
+            };
+          no-check-files =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Skip verifying spelling in files.";
+              default = false;
+            };
+          no-unicode =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Only allow ASCII characters in identifiers.";
+              default = false;
+            };
+          quiet =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "Less output per occurence.";
+              default = false;
+            };
+          verbose =
+            mkOption {
+              type = types.bool;
+              description = lib.mdDoc "More output per occurence.";
+              default = false;
+            };
           write =
             mkOption {
               type = types.bool;
-              description = lib.mdDoc "Whether to fix spelling in files by writing them. Cannot be used with `typos.settings.diff`.";
+              description = lib.mdDoc "Fix spelling in files by writing them. Cannot be used with `typos.settings.diff`.";
               default = false;
             };
         };
@@ -2423,20 +2451,28 @@ in
           description = "Source code spell checker";
           entry =
             let
-              configFile = builtins.toFile "config.toml" "${settings.typos.config}";
+              configFile = builtins.toFile "typos-config.toml" "${settings.typos.config}";
               cmdArgs =
                 mkCmdArgs
                   (with settings.typos; [
-                    [ (color != "") "--color ${color}" ]
-                    [ (configPath != "") "--config ${configPath}" ]
-                    [ (config != "" && configPath == "") "--config ${configFile}" ]
+                    [ binary "--binary" ]
+                    [ (color != "auto") "--color ${color}" ]
+                    [ (config != "") "--config ${configFile}" ]
+                    [ (configPath != "" && config == "") "--config ${configPath}" ]
+                    [ diff "--diff" ]
                     [ (exclude != "") "--exclude ${exclude} --force-exclude" ]
-                    [ (format != "") "--format ${format}" ]
-                    [ (locale != "") "--locale ${locale}" ]
+                    [ (format != "long") "--format ${format}" ]
+                    [ hidden "--hidden" ]
+                    [ (locale != "en") "--locale ${locale}" ]
+                    [ no-check-filenames "--no-check-filenames" ]
+                    [ no-check-files "--no-check-files" ]
+                    [ no-unicode "--no-unicode" ]
+                    [ quiet "--quiet" ]
+                    [ verbose "--verbose" ]
                     [ (write && !diff) "--write-changes" ]
                   ]);
             in
-            "${tools.typos}/bin/typos ${cmdArgs}${lib.optionalString settings.typos.diff " --diff"}${lib.optionalString settings.typos.hidden " --hidden"}";
+            "${tools.typos}/bin/typos ${cmdArgs}";
           types = [ "text" ];
           # Typos is supposed to run on the whole tree. If this is set to true,
           # the system gets stuck for large projects due to very high memory

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1147,6 +1147,16 @@ in
               description = lib.mdDoc "Search hidden files and directories.";
               default = false;
             };
+          ignored-words =
+            mkOption {
+              type = types.listOf types.str;
+              description = lib.mdDoc "Spellings and words to ignore.";
+              default = [ ];
+              example = [
+                "MQTT"
+                "mosquitto"
+              ];
+            };
           locale =
             mkOption {
               type = types.enum [ "en" "en-us" "en-gb" "en-ca" "en-au" ];
@@ -2451,7 +2461,9 @@ in
           description = "Source code spell checker";
           entry =
             let
-              configFile = builtins.toFile "typos-config.toml" "${settings.typos.config}";
+              # Concatenate config in config file with section for ignoring words generated from list of words to ignore
+              config = "${settings.typos.config}" + lib.strings.optionalString (settings.typos.ignored-words != [ ]) "\n\[default.extend-words\]" + lib.strings.concatMapStrings (x: "\n${x} = \"${x}\"") settings.typos.ignored-words;
+              configFile = builtins.toFile "typos-config.toml" config;
               cmdArgs =
                 mkCmdArgs
                   (with settings.typos; [

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2486,11 +2486,6 @@ in
             in
             "${tools.typos}/bin/typos ${cmdArgs}";
           types = [ "text" ];
-          # Typos is supposed to run on the whole tree. If this is set to true,
-          # the system gets stuck for large projects due to very high memory
-          # consumption. The restriction on with files typos run, should be
-          # specified in the typos config file.
-          pass_filenames = false;
         };
       typstfmt = {
         name = "typstfmt";


### PR DESCRIPTION
### Adding options for existing flags
I've added a few more options to the `typos` hook to pass existing command line flags.
These options are `binary`, `no-check-filenames`, `no-check-files`, `no-unicode`, `quiet`, `verbose`.
I also refactored the descriptions of the options and `cmdArgs` of the hook a bit.

### Adding an option to ignore files
[I asked in the `typos` repo](https://github.com/crate-ci/typos/discussions/907) how to best ignore words, that should not be marked as typos. The way `typos` works, you have to add these words/spellings to the word list by extending it.
Due to some design decisions, `typos` maintainers will not introduce CLI flags to ignore words and will to stick to the use of a single config file (_typos.toml) for that.

To make `typos` even more usable as a pre-commit hook, I've added an option to list words to be ignored in the configuration of the hook. This makes it possible to set the following:

```nix
settings.typos.ignored-words = [
  "mqtt"
  "mosquitto"
  ];
```

If the option is set, the list of words then gets appended to a passed config file in a way `typos` understands.
The resulting config file passed to the hook then contains the required section:

```toml
[default.extend-words]
mqtt = "mqtt"
mosquitto = "mosquitto"
```

If both `settings.typos.config` and `settings.typos.configPath` are set, the latter gets ignored. This is now documented in the option's description, so that users know not to configure both.

### Unsetting `pass_filenames`
In commit f441d0892f47d199a1a96b0c0efec13fdbff01ee, I have removed the recent change from @phip1611. [I stated in the PR discussion](https://github.com/cachix/pre-commit-hooks.nix/pull/387#issuecomment-1893321739) why I think changing this was not a good idea.
@domenkozar Perhaps we can wait for @phip1611's response and discuss this in https://github.com/cachix/pre-commit-hooks.nix/pull/387 before this PR gets merged. 