### PR TITLE
docs: use formal capitalization of JavaScript/TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ use nix
 
 - [purty](https://gitlab.com/joneshf/purty)
 
-## Javascript/Typescript
+## JavaScript/TypeScript
 
 - denofmt: Runs `deno fmt`
 - denolint: Runs `deno lint`


### PR DESCRIPTION
Formal capitalization taken from developer.mozilla.org[^1] and typescriptlang.org[^2].

[^1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript
[^2]: https://www.typescriptlang.org/