### PR TITLE
Changing files is consistent with other formatting pre-commit hooks (prettier)

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -744,13 +744,13 @@ in
             mkOption {
               description = lib.mdDoc "Output a human-friendly message and a list of unformatted files, if any.";
               type = types.bool;
-              default = true;
+              default = false;
             };
           list-different =
             mkOption {
               description = lib.mdDoc "Print the filenames of files that are different from Prettier formatting.";
               type = types.bool;
-              default = false;
+              default = true;
             };
           color =
             mkOption {
@@ -800,7 +800,7 @@ in
             mkOption {
               description = lib.mdDoc "Ignore unknown files.";
               type = types.bool;
-              default = false;
+              default = true;
             };
           insert-pragma =
             mkOption {
@@ -933,7 +933,7 @@ in
             mkOption {
               description = lib.mdDoc "Edit files in-place.";
               type = types.bool;
-              default = false;
+              default = true;
             };
         };
       psalm =


### PR DESCRIPTION
A previous PR[^1] changed the expected behavior of prettier pre-commit-hook from `prettier . --write --ignore-unknown --list-different` to `prettier . --check`.

Another previous PR[^2] sets the precedent that pre-commit-hooks should not just `check` but actually `write` formatting changes.

[^1]: https://github.com/cachix/pre-commit-hooks.nix/commit/02a459585885f57c3fd93bb4e0b9b573a62a1ee5
[^2]: https://github.com/cachix/pre-commit-hooks.nix/pull/269