### PR TITLE
feat: introduce black flags

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -136,6 +136,20 @@ in
           };
         };
       };
+      black = mkOption {
+        description = lib.mdDoc "black hook";
+        type = types.submodule {
+          imports = hookModule;
+          options.settings = {
+            flags = mkOption {
+              type = types.str;
+              description = lib.mdDoc "Flags passed to black. See all available [here](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options).";
+              default = "";
+              example = "--skip-magic-trailing-comma";
+            };
+          };
+        };
+      };
       clippy = mkOption {
         description = lib.mdDoc "clippy hook";
         type = types.submodule {
@@ -1596,7 +1610,7 @@ in
           name = "black";
           description = "The uncompromising Python code formatter";
           package = tools.black;
-          entry = "${hooks.black.package}/bin/black";
+          entry = "${hooks.black.package}/bin/black ${hooks.black.settings.flags}";
           types = [ "file" "python" ];
         };
       cabal-fmt =


### PR DESCRIPTION
This PR adds `setting.black.flags` making the `black` hook more configurable. Default is no flags.

All options are listed [here](https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#command-line-options), it is documented in the nix option.

I first thought about mirroring all options but this way is more flexible imho. My primary intention is to support `--experimental-string-processing` with this (which will change to `--preview --enable-unstable-feature string_processing` in black v24, see the [change logs](https://black.readthedocs.io/en/stable/change_log.html#id8), another advantage of a generic  `flags` argument). Of course, further options for specific arguments can be added later.