### PR TITLE
rustfmt: Support multi package projects

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2706,7 +2706,7 @@ in
           description = "Format Rust code.";
           package = wrapper;
           packageOverrides = { cargo = tools.cargo; rustfmt = tools.rustfmt; };
-          entry = "${hooks.rustfmt.package}/bin/cargo-fmt fmt ${cargoManifestPathArg} -- --color always";
+          entry = "${hooks.rustfmt.package}/bin/cargo-fmt fmt ${cargoManifestPathArg} --all -- --color always";
           files = "\\.rs$";
           pass_filenames = false;
         };


### PR DESCRIPTION
Fixes the error `Failed to find targets`, followed by the help text.

I've tested this change with both a multi-package and a single-package project.
