### PR TITLE
Add `check_phase` to pre-commit settings

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -69,14 +69,14 @@ let
       git config --global user.email "you@example.com"
       git config --global user.name "Your Name"
       git commit -m "init"
-      if [[ ${toString (compare install_stages [ "manual" ])} -eq 0 ]]
-      then
-        echo "Running: $ pre-commit run --hook-stage manual --all-files"
-        ${cfg.package}/bin/pre-commit run --hook-stage manual --all-files
-      else
-        echo "Running: $ pre-commit run --all-files"
-        ${cfg.package}/bin/pre-commit run --all-files
-      fi
+      local check_stage=${toString cfg.check_stage}
+      case $check_stage in
+        commit | merge-commit | push)
+          check_stage="pre-"$check_stage
+          ;;
+      esac
+      echo "Running: $ pre-commit run --hook-stage $check_stage --all-files"
+      ${cfg.package}/bin/pre-commit run --hook-stage $check_stage --all-files
       exitcode=$?
       git --no-pager diff --color
       touch $out
@@ -261,6 +261,16 @@ in
               See [https://pre-commit.com/#confining-hooks-to-run-at-certain-stages](https://pre-commit.com/#confining-hooks-to-run-at-certain-stages).
             '';
           default = [ "commit" ];
+        };
+
+      check_stage =
+        mkOption {
+          type = types.str;
+          description = lib.mdDoc
+            ''
+              This is pre-commit stage to be used in a nix `checkPhase`. `commit` maps to `pre-commit`, which is `pre-commit`'s default.
+            '';
+          default = "commit";
         };
 
       rawConfig =

--- a/nix/run.nix
+++ b/nix/run.nix
@@ -5,6 +5,7 @@ builtinStuff@{ pkgs, tools, isFlakes, pre-commit, git, runCommand, writeText, wr
 , hooks ? { }
 , excludes ? [ ]
 , tools ? { }
+, check_stage ? "commit"
 , default_stages ? [ "commit" ]
 }:
 let
@@ -18,7 +19,7 @@ let
               {
                 _module.args.pkgs = pkgs;
                 _module.args.gitignore-nix-src = gitignore-nix-src;
-                inherit hooks excludes default_stages settings;
+                inherit hooks excludes default_stages check_stage settings;
                 tools = builtinStuff.tools // tools;
                 package = pre-commit;
               } // (if isFlakes


### PR DESCRIPTION
The existing behavior of `pre-commit-hooks.nix` is to use the `pre-commit` phase of pre-commit hooks, unless your `default_phases = [ "manual" ]`. On further inspection I found that it has to be only `manual`. If `default_phases = [ "manual" "push" ]`, it will use `commit`. In my particular case, I wanted `default_phases = [ "push" ]`, which then ran `commit` hooks when I ran `nix flake check`.

This PR adds `check_phase` to the configuration. Setting `check_phase = "push"` runs the `pre-push`  phase checks when I run `nix flake check` no matter what my `default_phases` are.