### PR TITLE
feat: add uv hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ use nix
 - [ruff-format](https://github.com/charliermarsh/ruff)
 - [single-quoted-strings](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/string_fixer.py)
 - [sort-requirements-txt](https://github.com/pre-commit/pre-commit-hooks/blob/main/pre_commit_hooks/requirements_txt_fixer.py)
+- [uv](https://github.com/astral-sh/uv)
 
 ### Rust
 

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -93,6 +93,7 @@
 , golangci-lint
 , golines
 , revive ? null
+, uv
 , vale
 }:
 
@@ -172,6 +173,7 @@ in
     typos
     typstfmt
     typstyle
+    uv
     vale
     yamlfmt
     yamllint


### PR DESCRIPTION
Useful for Python projects managed with `uv`.
For example to conform with the new [PEP 751](https://peps.python.org/pep-0751/), it might make sense to run `uv export` as a hook to export the locked dependencies from `uv`'s default lockfile `uv.lock` to a `pylock.toml`.