### PR TITLE
ci: update stable nixpkgs to 25.05

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,5 +58,4 @@ jobs:
     - run: rm -rf /opt&
 
     - name: Check nixpkgs-stable
-      run: nix flake check -L --show-trace --override-input nixpkgs github:NixOS/nixpkgs/nixos-24.11
-
+      run: nix flake check -L --show-trace --override-input nixpkgs github:NixOS/nixpkgs/nixos-25.05


### PR DESCRIPTION
I know that we're already approaching the release window of 25.11, but this _seems_ to be a zero-cost change so I figured I might as well suggest it.

Actions jobs are [all green](https://github.com/lafrenierejm/git-hooks.nix/actions/runs/17639355079) for this branch on my fork.