### PR TITLE
Remove typstfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,7 +478,6 @@ use nix
 
 ### Typst
 
-- [typstfmt](https://github.com/astrale-sharp/typstfmt)
 - [typstyle](https://github.com/Enter-tainer/typstyle)
 
 ### YAML

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4253,13 +4253,6 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
             (lib.genAttrs hooks.typos.settings.ignored-words lib.id);
           types = [ "text" ];
         };
-      typstfmt = {
-        name = "typstfmt";
-        description = "format typst";
-        package = tools.typstfmt;
-        entry = "${hooks.typstfmt.package}/bin/typstfmt";
-        files = "\\.typ$";
-      };
       typstyle = {
         name = "typstyle";
         description = "Beautiful and reliable typst code formatter";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -89,7 +89,6 @@
 , treefmt
 , trufflehog
 , typos
-, typstfmt
 , typstyle ? null ## Add in nixpkgs added on commit 800ca60
 , woodpecker-cli
 , zprint
@@ -186,7 +185,6 @@ in
     treefmt
     trufflehog
     typos
-    typstfmt
     typstyle
     uv
     vale


### PR DESCRIPTION
Removes all references to typstfmt, which has been removed from nixpkgs-unstable, users should use typstyle instead.

Error on current nixpkgs:
```
error: 'typstfmt' has been removed due to lack of upstream maintenance, consider using 'typstyle' instead
```

[nixpkgs removal commit](https://github.com/NixOS/nixpkgs/commit/9aced175e9cc44332f28e6a9f355ef168be8ba66) 
Relates to [648](https://github.com/cachix/git-hooks.nix/issues/648)
