### PR TITLE
feat: Add oxlint hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1068,6 +1068,100 @@ in
           };
         };
       };
+      oxlint = mkOption {
+        description = "oxlint hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings = {
+            categories =
+              mkOption {
+                type = types.listOf (types.submodule {
+                  options = {
+                    action = mkOption {
+                      type = types.enum [ "allow" "warn" "deny" ];
+                      description = "Whether to allow a category and suppress its lints, deny a category and emit warnings, or deny and emit an error.";
+                    };
+                    category = mkOption {
+                      type = types.enum [ "correctness" "suspicious" "pedantic" "style" "nursery" "restriction" "all" ];
+                      description = ''
+                        * `correctness` - code that is outright wrong or useless (default).
+                        * `suspicious`  - code that is most likely wrong or useless.
+                        * `pedantic`    - lints which are rather strict or have occasional false positives.
+                        * `style`       - code that should be written in a more idiomatic way.
+                        * `nursery`     - new lints that are still under development.
+                        * `restriction` - lints which prevent the use of language and library features.
+                        * `all`         - all the categories listed above except nursery. Does not enable plugins
+                      '';
+                    };
+                  };
+                });
+                description = "List of action-category pairs";
+                default = [ ];
+                example = [
+                  { action = "deny"; category = "correctness"; }
+                  { action = "allow"; category = "no-debugger"; }
+                ];
+              };
+            configPath = mkOption {
+              type = types.nullOr (types.oneOf [ types.str types.path ]);
+              description = "Oxlint configuration file. Only `.json` extension is supported.";
+              default = null;
+              example = "./oxlintrc.json";
+            };
+            deny-warnings = mkOption {
+              type = types.bool;
+              description = "Ensure warnings produce a non-zero exit code.";
+              default = false;
+            };
+            fix = mkOption {
+              type = types.nullOr (types.enum [ "safe" "suggestions" "dangerously" ]);
+              description = "Which issue fixes to apply";
+              default = null;
+            };
+            format = mkOption {
+              type = types.enum [ "checkstyle" "default" "github" "gitlab" "json" "junit" "stylish" "unix" ];
+              description = "Use a specific output format.";
+              default = "default";
+            };
+            max-warnings = mkOption {
+              type = types.nullOr types.int;
+              description = "Specify a warning threshold, which can be used to force exit with an error status if there are too many warning-level rule violations in your project.";
+              default = null;
+            };
+            plugins = mkOption {
+              type = types.listOf (types.enum [ "import" "jest" "jsdoc" "jsx-a11y" "nextjs" "node" "oxc" "promise" "react" "react-perf" "regex" "typescript" "unicorn" "vitest" "vue" ]);
+              description = "The plugins to enable.";
+              default = [ "oxc" "unicorn" "typescript" ];
+            };
+            quiet = mkOption {
+              type = types.bool;
+              description = "Disable reporting on warnings, only errors are reported.";
+              default = false;
+            };
+            report-unused-disable-directives-severity = mkOption {
+              type = types.nullOr (types.enum [ "error" "warn" "log" "debug" ]);
+              description = "Specify the severity level of directive comments like `// eslint-disable-line` when no errors would have been reported on that line anyway.";
+              default = null;
+            };
+            silent = mkOption {
+              type = types.bool;
+              description = "Do not display any diagnostics.";
+              default = false;
+            };
+            threads = mkOption {
+              type = types.nullOr types.int;
+              description = "Number of threads to use. Set to 1 for using only 1 CPU core.";
+              default = null;
+            };
+            tsconfigPath = mkOption {
+              type = types.nullOr (types.oneOf [ types.str types.path ]);
+              description = "TypeScript `tsconfig.json` path for reading path alias and project references for import plugin.";
+              default = null;
+              example = "./tsconfig.json";
+            };
+          };
+        };
+      };
       php-cs-fixer = mkOption {
         description = "php-cs-fixer hook";
         type = types.submodule {
@@ -3582,6 +3676,41 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
             in
             "${hooks.ormolu.package}/bin/ormolu --mode inplace ${extensions} ${cabalExtensions}";
           files = "\\.l?hs(-boot)?$";
+        };
+      oxlint =
+        {
+          name = "oxlint";
+          description = "ESLint replacement written in Rust";
+          package = tools.oxlint;
+          entry =
+            let
+              pluginsDefault = [ "oxc" "unicorn" "typescript" ];
+              cmdArgs =
+                mkCmdArgs
+                  (with hooks.oxlint.settings; [
+                    [ (categories != [ ]) (lib.strings.concatStringsSep " " (lib.concatMap (entry: [ "--${entry.0}=${entry.1}" ]) categories)) ]
+                    [ (config-path != null) "--config=${builtins.toString config-path}" ]
+                    [ (deny-warnings != null) "--deny-warnings" ]
+                    [ (fix != null) (if fix == "safe" then "--fix" else "--fix=${fix}") ]
+                    [ (true) "--format=${format}" ]
+                    [ (max-warnings != null) "--max-warnings=${builtins.toString max-warnings}" ]
+                    [
+                      (plugins != [ ])
+                      (lib.strings.concatStringsSep " "
+                        (flatten [
+                          (lib.concatMap (plugin: [ "--${plugin}-plugin" ]) (lib.subtractLists pluginsDefault plugins))
+                          (lib.concatMap (plugin: [ "--disable-${plugin}-plugin" ]) (lib.subtractLists plugins pluginsDefault))
+                        ]))
+                    ]
+                    [ (quiet) "--quiet" ]
+                    [ (report-unused-disable-directives-severity != null) "--report-unused-disable-directives-severity=${report-unused-disable-directives-severity}" ]
+                    [ (silent) "--silent" ]
+                    [ (threads != null) "--threads=${builtins.toString threads}" ]
+                    [ (tsconfig-path != null) "--tsconfig=${builtins.toString tsconfig-path}" ]
+                  ]);
+            in
+            "${hooks.oxlint.package}/bin/oxlint ${cmdArgs}";
+          types_or = [ "javascript" "jsx" "ts" "tsx" ];
         };
       php-cs-fixer =
         {

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -63,6 +63,7 @@
 , opam
 , opentofu
 , ormolu
+, oxlint
 , pkgsBuildBuild
 , poetry
 , pre-commit-hook-ensure-sops ? null
@@ -165,6 +166,7 @@ in
     nixpkgs-fmt
     opentofu
     ormolu
+    oxlint
     pre-commit-hook-ensure-sops
     poetry
     proselint


### PR DESCRIPTION
Adds support for [oxlint](https://oxc.rs/docs/guide/usage/linter.html) version 1.12.0. Closes #595.

<details>
<summary>The full output of <code>oxlint --help</code> for reference</summary>

```console
$ oxlint --help
Usage: [-c=<./oxlintrc.json>] [PATH]...

Basic Configuration
    -c, --config=<./oxlintrc.json>  Oxlint configuration file (experimental)
                              * only `.json` extension is supported
                              * tries to be compatible with the ESLint v8's format
        --tsconfig=<./tsconfig.json>  TypeScript `tsconfig.json` path for reading path alias and
                              project references for import plugin
        --init                Initialize oxlint configuration with default values

Allowing / Denying Multiple Lints
   Accumulate rules and categories from left to right on the command-line.
   For example `-D correctness -A no-debugger` or `-A all -D no-debugger`.
   The categories are:
   * `correctness` - code that is outright wrong or useless (default).
   * `suspicious`  - code that is most likely wrong or useless.
   * `pedantic`    - lints which are rather strict or have occasional false positives.
   * `style`       - code that should be written in a more idiomatic way.
   * `nursery`     - new lints that are still under development.
   * `restriction` - lints which prevent the use of language and library features.
   * `all`         - all the categories listed above except nursery. Does not enable plugins
  automatically.
    -A, --allow=NAME          Allow the rule or category (suppress the lint)
    -W, --warn=NAME           Deny the rule or category (emit a warning)
    -D, --deny=NAME           Deny the rule or category (emit an error)

Enable Plugins
        --disable-unicorn-plugin  Disable unicorn plugin, which is turned on by default
        --disable-oxc-plugin  Disable oxc unique rules, which is turned on by default
        --disable-typescript-plugin  Disable TypeScript plugin, which is turned on by default
        --import-plugin       Enable the experimental import plugin and detect ESM problems. It is
                              recommended to use along side with the `--tsconfig` option.
        --react-plugin        Enable react plugin, which is turned off by default
        --jsdoc-plugin        Enable the experimental jsdoc plugin and detect JSDoc problems
        --jest-plugin         Enable the Jest plugin and detect test problems
        --vitest-plugin       Enable the Vitest plugin and detect test problems
        --jsx-a11y-plugin     Enable the JSX-a11y plugin and detect accessibility problems
        --nextjs-plugin       Enable the Next.js plugin and detect Next.js problems
        --react-perf-plugin   Enable the React performance plugin and detect rendering performance
                              problems
        --promise-plugin      Enable the promise plugin and detect promise usage problems
        --node-plugin         Enable the node plugin and detect node usage problems
        --regex-plugin        Enable the regex plugin and detect regex usage problems
        --vue-plugin          Enable the vue plugin and detect vue usage problems

Fix Problems
        --fix                 Fix as many issues as possible. Only unfixed issues are reported in
                              the output
        --fix-suggestions     Apply auto-fixable suggestions. May change program behavior.
        --fix-dangerously     Apply dangerous fixes and suggestions.

Ignore Files
        --ignore-path=PATH    Specify the file to use as your .eslintignore
        --ignore-pattern=PAT  Specify patterns of files to ignore (in addition to those in
                              .eslintignore)
        --no-ignore           Disables excluding of files from .eslintignore files, --ignore-path
                              flags and --ignore-pattern flags

Handle Warnings
        --quiet               Disable reporting on warnings, only errors are reported
        --deny-warnings       Ensure warnings produce a non-zero exit code
        --max-warnings=INT    Specify a warning threshold, which can be used to force exit with an
                              error status if there are too many warning-level rule violations in
                              your project

Output
    -f, --format=ARG          Use a specific output format. Possible values: `checkstyle`,
                              `default`, `github`, `gitlab`, `json`, `junit`, `stylish`, `unix`

Miscellaneous
        --silent              Do not display any diagnostics
        --threads=INT         Number of threads to use. Set to 1 for using only 1 CPU core
        --print-config        This option outputs the configuration to be used. When present, no
                              linting is performed and only config-related options are valid.

Inline Configuration Comments
        --report-unused-disable-directives  Report directive comments like `// eslint-disable-line`
                              when no errors would have been reported on that line anyway.
        --report-unused-disable-directives-severity=SEVERITY  Same as
                              `--report-unused-disable-directives`, but allows you to specify the
                              severity level of the reported errors. Only one of these two options
                              can be used at a time.

Available positional items:
    PATH                      Single file, single path or list of paths

Available options:
        --rules               list all the rules that are currently registered
        --disable-nested-config  Disables the automatic loading of nested configuration files.
        --type-aware          Enables rules that require type information.
    -h, --help                Prints help information
    -V, --version             Prints version information
```

</details>