### PR TITLE
use prek

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -168,9 +168,9 @@ in
             ''
               The `pre-commit` package to use.
             '';
-          default = pkgs.pre-commit;
-          defaultText = lib.literalExpression "pkgs.pre-commit";
-          example = lib.literalExpression "pkgs.prek";
+          default = pkgs.prek;
+          defaultText = lib.literalExpression "pkgs.prek";
+          example = lib.literalExpression "pkgs.pre-commit";
         };
 
       gitPackage =


### PR DESCRIPTION
Should we provide `pre-commit` binary as an alias to `prek`? That way less of usages will break.

```
● CLI Comparison: prek vs pre-commit

  | Aspect  | prek (Rust) | pre-commit (Python) |
  |---------|-------------|---------------------|
  | Version | 0.2.17      | 4.3.0               |

  Shared Commands

  Both have: install, install-hooks, run, uninstall, validate-config,
  validate-manifest, sample-config, autoupdate/auto-update,
  init-templatedir/init-template-dir, try-repo

  prek-only

  - list - List available hooks
  - cache - Manage cache
  - self - Self management

  pre-commit-only

  - clean - Clean pre-commit files
  - gc - Clean unused cached repos
  - migrate-config - Migrate list to map configuration
  - help - Show help for specific command
  - hook-impl - (internal)

  Key Differences

  - prek allows inline options (e.g., --all-files, --files, --from-ref,
  --show-diff-on-failure) at top level
  - pre-commit requires subcommand first, then options (e.g., pre-commit run
  --all-files)
  - prek has --dry-run, --log-file, --no-progress options
  - prek supports --color with env var PREK_COLOR
  - prek has hook/project filtering with positional args and --skip
  ```