### PR TITLE
feat(nil) Add option to treat warnings as errors

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -972,6 +972,19 @@ in
           imports = [ hookModule ];
         };
       };
+      nil = mkOption {
+        description = "nil hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings = {
+            denyWarnings = mkOption {
+              type = types.bool;
+              description = "Treat warnings like errors and exit with non-zero code";
+              default = false;
+            };
+          };
+        };
+      };
       nixf-diagnose = mkOption {
         description = "nixf-diagnose hook";
         type = types.submodule {
@@ -3474,11 +3487,14 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
           package = tools.nil;
           entry =
             let
+              cmdArgs = mkCmdArgs (with hooks.nil.settings; [
+                [ denyWarnings "--deny-warnings" ]
+              ]);
               script = pkgs.writeShellScript "precommit-nil" ''
                 errors=false
                 echo Checking: $@
                 for file in $(echo "$@"); do
-                  ${hooks.nil.package}/bin/nil diagnostics "$file"
+                  ${hooks.nil.package}/bin/nil diagnostics ${cmdArgs} "$file"
                   exit_code=$?
 
                   if [[ $exit_code -ne 0 ]]; then


### PR DESCRIPTION
Enables the passing of `--deny-warnings` to `nil` in order to treat warnings as errors.