### PR TITLE
feat: add cue

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ use nix
 
 - [crystal](https://crystal-lang.org/reference/man/crystal#crystal-tool-format)
 
+### CUE
+
+- [cue-fmt](https://github.com/cue-lang/cue)
+
 ### Dart
 
 - [dart analyze](https://dart.dev/tools/dart-analyze)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2661,6 +2661,13 @@ in
         entry = "${hooks.crystal.package}/bin/crystal tool format";
         files = "\\.cr$";
       };
+      cue-fmt = {
+        name = "cue fmt";
+        description = "Format CUE files";
+        package = tools.cue;
+        entry = "${hooks.cue-fmt.package}/bin/cue fmt";
+        files = "\\.cue$";
+      };
       cspell =
         {
           name = "cspell";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -21,6 +21,7 @@
 , conform
 , convco
 , crystal
+, cue
 , dart
 , deadnix
 , deno
@@ -132,6 +133,7 @@ in
     conform
     convco
     crystal
+    cue
     dart
     deadnix
     deno


### PR DESCRIPTION
Hey! This PR is adding [cue formatter](https://cuelang.org/).

In the current version of `flake.lock` some stuff like `nix develop` and `nix flake check` didn't work for me until I update the flake + remove purty because it isn't supported by nixpkgs anymore.