### PR TITLE
feat(modules/hook): change "system" language to "unsupported"

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,9 +571,9 @@ Example configuration:
          excludes = [ "irrelevant\\.c" ];
 
          # The language of the hook - tells pre-commit
-         # how to install the hook (default: "system")
+         # how to install the hook (default: "unsupported")
          # see also https://pre-commit.com/#supported-languages
-         language = "system";
+         language = "unsupported";
 
          # Set this to false to not pass the changed files
          # to the command (default: true):

--- a/modules/hook.nix
+++ b/modules/hook.nix
@@ -108,7 +108,7 @@ in
         ''
           The language of the hook - tells pre-commit how to install the hook.
         '';
-      default = "system";
+      default = "unsupported";
     };
 
     files = mkOption {


### PR DESCRIPTION
`language: system` is getting deprecated and replaced with `language: unsupported` since Pre-commit v4.4.0[^1][^2]

[^1]: https://github.com/pre-commit/pre-commit/releases/tag/v4.4.0
[^2]: https://pre-commit.com/#unsupported

There's no warnings yet, but let's get ready just in case