### PR TITLE
hooks: update deprecated lib.cli functions

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3948,10 +3948,10 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
             let
               inherit (hooks) rustfmt;
               inherit (rustfmt) settings;
-              cargoArgs = lib.cli.toGNUCommandLineShell { } {
+              cargoArgs = lib.cli.toCommandLineShellGNU { } {
                 inherit (settings) all package verbose manifest-path;
               };
-              rustfmtArgs = lib.cli.toGNUCommandLineShell { } {
+              rustfmtArgs = lib.cli.toCommandLineShellGNU { } {
                 inherit (settings) check emit config-path color files-with-diff config verbose;
               };
             in
@@ -4063,17 +4063,14 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
           entry =
             let
               inherit (hooks.statix) package settings;
-              mkOptionName = k:
-                if builtins.stringLength k == 1
-                then "-${k}"
-                else "--${k}";
-              options = lib.cli.toGNUCommandLineShell
-                {
-                  # instead of repeating the option name for each element,
-                  # create a single option with a space-separated list of unique values.
-                  mkList = k: v: if v == [ ] then [ ] else [ (mkOptionName k) ] ++ lib.unique v;
-                }
-                settings;
+              options = lib.cli.toCommandLineShellGNU
+                { }
+                (lib.mapAttrs
+                  (_: v:
+                    if builtins.isList v
+                    then builtins.concatStringsSep "," (lib.unique v)
+                    else v)
+                  settings);
             in
             "${package}/bin/statix check ${options}";
           files = "\\.nix$";


### PR DESCRIPTION
closes #673.

```
evaluation warning: lib.cli.toGNUCommandLineShell is deprecated, please use lib.cli.toCommandLineShell or lib.cli.toCommandLineShellGNU instead.
evaluation warning: lib.cli.toGNUCommandLine is deprecated, please use lib.cli.toCommandLine or lib.cli.toCommandLineShellGNU instead.
```