### PR TITLE
hooks: fix argument rendering for statix

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4070,16 +4070,21 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
           entry =
             let
               inherit (hooks.statix) package settings;
-              options = lib.cli.toCommandLineShellGNU
-                { }
+              optionFormat = optionName: {
+                option = "--${optionName}";
+                sep = null;
+                explicitBool = false;
+              };
+              options = lib.cli.toCommandLine
+                optionFormat
                 (lib.mapAttrs
                   (_: v:
                     if builtins.isList v
-                    then builtins.concatStringsSep "," (lib.unique v)
+                    then builtins.concatStringsSep " " (lib.unique v)
                     else v)
                   settings);
             in
-            "${package}/bin/statix check ${options}";
+            "${package}/bin/statix check ${toString options}";
           files = "\\.nix$";
           pass_filenames = false;
         };


### PR DESCRIPTION
Argument rendering for `statix` is broken since https://github.com/cachix/git-hooks.nix/pull/674/commits/7304260a05321b0a98039b8416df38a6cb772932. It's not possible anymore to pass multiple files to `statix.settings.ignore`.

I have the following configuration:

```nix
  hooks = {
    statix = {
      enable = true;
      settings.ignore = [
        "foo.nix"
        "bar.nix"
      ];
    };
};
```

Before https://github.com/cachix/git-hooks.nix/pull/674/commits/7304260a05321b0a98039b8416df38a6cb772932 this resulted in 

```shell
/nix/store/...-statix-0.5.8/bin/statix check --format errfmt --ignore foo.nix bar.nix
```

Since https://github.com/cachix/git-hooks.nix/pull/674/commits/7304260a05321b0a98039b8416df38a6cb772932, it's rendered as

```shell
/nix/store/...-statix-0.5.8/bin/statix check '--format=errfmt' '--ignore=foo.nix,bar.nix'
```

which is interpreted as a single pattern to ignore (`foo.nix,bar.nix`) by statix.

With this change, args are rendered as before again without calling deprecated lib.cli functions:

```shell
/nix/store/...-statix-0.5.8/bin/statix check --format errfmt --ignore foo.nix bar.nix
```