### PR TITLE
hooks: remove empty default for statix.settings.ignore

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1560,9 +1560,9 @@ in
 
             ignore =
               mkOption {
-                type = types.listOf types.str;
+                type = types.nullOr (types.listOf types.str);
                 description = "Globs of file patterns to skip.";
-                default = [ ];
+                default = null;
                 example = [ "flake.nix" "_*" ];
               };
 


### PR DESCRIPTION
Don't need unused command args that cause issue with generating output.

Fixes https://github.com/cachix/git-hooks.nix/pull/679#issuecomment-3773969543 with default statix enablement. 