### PR TITLE
deps: bump nixpkgs to fix Lix evaluation errors when using `default.nix` entrypoint

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1764947035,
-        "narHash": "sha256-EYHSjVM4Ox4lvCXUMiKKs2vETUSL5mx+J2FfutM7T9w=",
+        "lastModified": 1770073757,
+        "narHash": "sha256-Vy+G+F+3E/Tl+GMNgiHl9Pah2DgShmIUBJXmbiQPHbI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a672be65651c80d3f592a89b3945466584a22069",
+        "rev": "47472570b1e607482890801aeaf29bfb749884f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Currently, importing this repo with the `default.nix` entrypoint results in evaluation failures on recent development builds of Lix, since it uses the flake's nixpkgs to build pre-commit, and the currently pinned checkout is from before NixOS/nixpkgs@a7b37ea, which fixes these evaluation failures. Since it's not possible to override the flake inputs when using flake-compat, this PR bumps nixpkgs to resolve the evaluation failures.

Lix evaluation error log, for reference:
```
error: dynamic attributes are not allowed within recursive attrsets, because they would be evaluated separately from the other recursive attributes. Use --extra-deprecated-features rec-set-dynamic-attrs to disable this error.
at /nix/store/9rf7z9hhnxqvbf5i04labfsxill2zhyl-source/pkgs/development/compilers/dotnet/packages.nix:161:5:
   160|
   161|     ${
      |     ^
   162|       if stdenvNoCC.hostPlatform.isDarwin && lib.versionAtLeast version "10" then "postInstall" else null

note: trace involved the following derivations:
derivation 'nix-shell'
derivation 'pre-commit-config.json'
derivation 'pre-commit-4.5.0'
```