### PR TITLE
Fix install.enable option and enable hook stage config in run derivation

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -483,7 +483,6 @@ in
             return 1
           fi
 
-          echo 1>&2 "git-hooks.nix: uninstalling hooks"
           # Remove any previously installed hooks (since pre-commit itself has no convergent design)
           hooks="${concatStringsSep " " (remove "manual" supportedHooksLib.supportedHooks )}"
           for hook in $hooks; do
@@ -505,7 +504,6 @@ in
             return 1
           fi
 
-          echo 1>&2 "git-hooks.nix: installing hooks"
           # Add hooks for configured stages (only) ...
           if [ ! -z "${concatStringsSep " " install_stages}" ]; then
             for stage in ${concatStringsSep " " install_stages}; do


### PR DESCRIPTION
**fix install.enable** option
this option's behavior does not match the description. Prior to this PR it bypasses building the yaml config. This PR defines a no-install branch in the `installationScript` which only builds and symlinks the `.pre-commit-config.yaml`

**runHookStage** option
If the user wants custom `default_stages` (e.g., `pre-push`) the run derivation needs an option to dictate which hook-stage gets run. This allows the user to append `manual` to `default_stages` and then invoke the manual hook-stage.