### PR TITLE
fix: correctly calculate core.hooksPath for git worktrees

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -526,7 +526,9 @@ in
               common_dir=''$(${cfg.gitPackage}/bin/git rev-parse --path-format=absolute --git-common-dir)
 
               # Convert the absolute path to a path relative to the toplevel working directory.
-              common_dir=''${common_dir#''$GIT_WC/}
+              # Using realpath instead of string stripping to correctly handle git worktrees
+              # where the common directory is not under the working tree.
+              common_dir=''$(${pkgs.coreutils}/bin/realpath --relative-to="''$GIT_WC" "''$common_dir")
 
               ${lib.getExe cfg.gitPackage} config --local core.hooksPath "''$common_dir/hooks"
             fi


### PR DESCRIPTION
## Summary

- Use `realpath --relative-to` instead of bash string stripping to compute the relative path to the git common directory
- Fixes the case where git worktrees have their common directory outside the working tree, causing `core.hooksPath` to be set incorrectly and hooks to silently not run

Fixes #688

## Test plan

- [ ] Set up a bare repo with a worktree where the common dir is not under the working tree
- [ ] Enter devenv shell to trigger hook installation
- [ ] Verify `git config --local core.hooksPath` points to the correct relative path (e.g. `../../.bare/hooks`)
- [ ] Verify hooks execute on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)