### PR TITLE
nix: make correct use of multiline strings

### DIFF
--- a/nix/cabal2nix-dir/default.nix
+++ b/nix/cabal2nix-dir/default.nix
@@ -1,6 +1,7 @@
 { writeScriptBin, cabal2nix }:
 
-writeScriptBin "cabal2nix-dir" ''#!/usr/bin/env bash
+writeScriptBin "cabal2nix-dir" ''
+  #!/usr/bin/env bash
   projectdir="$(pwd)"
   outputFileName=""
   cabalFiles=()

--- a/nix/hpack-dir/default.nix
+++ b/nix/hpack-dir/default.nix
@@ -1,6 +1,7 @@
 { writeScriptBin, hpack }:
 
-(writeScriptBin "hpack-dir" ''#!/usr/bin/env bash
+(writeScriptBin "hpack-dir" ''
+  #!/usr/bin/env bash
   set -e
   ##  ^^
   ## The `-e` flag changes the behaviour of Shell so that the first top-level

--- a/nix/hunspell/default.nix
+++ b/nix/hunspell/default.nix
@@ -1,18 +1,19 @@
 { writeScriptBin, hunspell }:
 
-writeScriptBin "hunspell" ''#!/usr/bin/env bash
+writeScriptBin "hunspell" ''
+  #!/usr/bin/env bash
 
-set -euo pipefail
-IFS=$'\n\t'
+  set -euo pipefail
+  IFS=$'\n\t'
 
-args=( "$@" )
+  args=( "$@" )
 
-misspelled_words=$(${hunspell}/bin/hunspell "''${args[@]}")
+  misspelled_words=$(${hunspell}/bin/hunspell "''${args[@]}")
 
-if [[ -n "$misspelled_words" ]]; then
-    echo "Misspelled words:"
-    echo "-----------------"
-    echo "$misspelled_words"
-    exit 1
-fi
+  if [[ -n "$misspelled_words" ]]; then
+      echo "Misspelled words:"
+      echo "-----------------"
+      echo "$misspelled_words"
+      exit 1
+  fi
 ''


### PR DESCRIPTION
> Whitespace calculations for indentation stripping in a multiline ''-string include the first line, so putting text on it will effectively disable all indentation stripping.