### PR TITLE
feat: validate terraform module without initializing backend

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4250,7 +4250,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
                   | sort \
                   | uniq \
                   | while read dir; do
-                      ${lib.getExe hooks.terraform-validate.package} -chdir="$dir" init
+                      ${lib.getExe hooks.terraform-validate.package} -chdir="$dir" init -backend=false
                       ${lib.getExe hooks.terraform-validate.package} -chdir="$dir" validate
                     done
               '';


### PR DESCRIPTION
Disables the unnecessary initialization of the Terraform backend before validating the Terraform module in `terraform-validate`.

See: https://developer.hashicorp.com/terraform/cli/commands/validate#introduction