### PR TITLE
Add nufmt hook for Nushell scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,6 +474,10 @@ hooks](modules/pre-commit.nix).
 - [nixpkgs-fmt](https://github.com/nix-community/nixpkgs-fmt)
 - [statix](https://github.com/nerdypepper/statix)
 
+### Nushell
+
+- [nufmt](https://github.com/nushell/nufmt)
+
 ### OCaml
 
 - [dune-fmt](https://dune.build/)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1071,6 +1071,19 @@ in
           };
         };
       };
+      nufmt = mkOption {
+        description = "nufmt hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings = {
+            configPath = mkOption {
+              type = types.nullOr types.path;
+              description = "Path to the nufmt.nuon configuration file.";
+              default = null;
+            };
+          };
+        };
+      };
       ormolu = mkOption {
         description = "ormolu hook";
         type = types.submodule {
@@ -3648,6 +3661,22 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
             in
             "${hooks.no-commit-to-branch.package}/bin/no-commit-to-branch ${cmdArgs}";
         };
+      nufmt =
+        {
+          name = "nufmt";
+          description = "Nushell code formatter.";
+          package = tools.nufmt;
+          entry =
+            let
+              cmdArgs =
+                mkCmdArgs
+                  (with hooks.nufmt.settings; [
+                    [ (configPath != null) "--config ${configPath}" ]
+                  ]);
+            in
+            "${lib.getExe hooks.nufmt.package} ${cmdArgs}";
+          types = [ "nushell" ];
+        };
       ocp-indent =
         {
           name = "ocp-indent";
@@ -4016,6 +4045,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
                 [ (configuration != { }) " --config ${toml.generate ".rumdl.toml" configuration}" ]
               ]);
         in
+
         {
           name = "rumdl";
           description = "Style checker and linter for rumdl files.";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -58,6 +58,7 @@
 , nixfmt-classic ? placeholder "nixfmt-classic"
 , nixfmt-rfc-style ? placeholder "nixfmt-rfc-style"
 , nixpkgs-fmt
+, nufmt ? placeholder "nufmt"
 , nodePackages
 , ocamlPackages
 , opam
@@ -166,6 +167,7 @@ in
     nil
     nixf-diagnose
     nixpkgs-fmt
+    nufmt
     opam
     opentofu
     ormolu


### PR DESCRIPTION
This PR adds a new nufmt hook to format Nushell (https://www.nushell.sh/) scripts, supporting an optional --config path for custom formatting rules.
