### PR TITLE
Add promtool-rules hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -1495,6 +1495,12 @@ in
           };
         };
       };
+      promtool-rules = mkOption {
+        description = "promtool-rules hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+        };
+      };
       psalm = mkOption {
         description = "psalm hook";
         type = types.submodule {
@@ -3928,6 +3934,14 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
                   ]);
             in
             "${hooks.proselint.package}/bin/proselint${cmdArgs} ${hooks.proselint.settings.flags}";
+        };
+      promtool-rules =
+        {
+          name = "promtool-rules";
+          description = "Validate Prometheus recording and alerting rules.";
+          package = tools.promtool;
+          entry = "${hooks.promtool-rules.package}/bin/promtool check rules";
+          types = [ "yaml" ];
         };
       psalm =
         {

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -72,6 +72,7 @@
 , poetry
 , pre-commit-hook-ensure-sops ? placeholder "pre-commit-hook-ensure-sops"
 , prettier
+, prometheus
 , proselint
 , python3Packages
 , pyright ? nodePackages.pyright
@@ -275,6 +276,7 @@ in
       bats;
 
   headache = callPackage ./headache { };
+  promtool = prometheus.cli;
 
   # Disable tests as these take way to long on our infra.
   julia-bin = julia-bin.overrideAttrs (_: _: { doInstallCheck = false; });


### PR DESCRIPTION
Add `promtool-rules` hook that validates Prometheus recording and alerting rules files using `promtool check rules`

Matches files with `.yaml` or `.yml` extension by default.