### PR TITLE
feat: add `cargo-sort` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ hooks](modules/pre-commit.nix).
 ### Rust
 
 - [cargo-check](https://doc.rust-lang.org/cargo/commands/cargo-check.html)
+- [cargo-sort](https://github.com/DevinR528/cargo-sort)
 - [clippy](https://github.com/rust-lang/rust-clippy)
 - [rustfmt](https://github.com/rust-lang/rustfmt)
 

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -2734,6 +2734,16 @@ in
           files = "\\.rs$";
           pass_filenames = false;
         };
+      cargo-sort =
+        {
+          name = "cargo-sort";
+          description = "Ensure Cargo.toml is sorted.";
+          package = tools.cargo-sort;
+          entry = "${hooks.cargo-sort.package}/bin/cargo-sort";
+          files = "Cargo\\.toml";
+          types = [ "file" "toml" ];
+          pass_filenames = false;
+        };
       chart-testing =
         {
           name = "chart-testing";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -10,6 +10,7 @@
 , cabal2nix
 , callPackage
 , cargo
+, cargo-sort
 , chart-testing
 , checkmake
 , circleci-cli
@@ -134,6 +135,7 @@ in
     biome
     cabal2nix
     cargo
+    cargo-sort
     chart-testing
     checkmake
     circleci-cli


### PR DESCRIPTION
## Summary

Add a [cargo-sort](https://github.com/devinr528/cargo-sort) hook based on the [official upstream pre-commit definition](https://github.com/DevinR528/cargo-sort/blob/main/.pre-commit-hooks.yaml).

## Changes

- add cargo-sort to modules/hooks.nix
- expose cargo-sort in nix/tools.nix
- document the hook in README.md

## Verification

- nix build .#checks.x86_64-linux.hook-config-test .#checks.x86_64-linux.all-tools-eval