### PR TITLE
Add an `inPlace` option for cmake-format

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -302,6 +302,11 @@ in
               default = "";
               example = ".cmake-format.json";
             };
+            inPlace = mkOption {
+              type = types.bool;
+              description = "Format files in place (`-i`) instead of only checking formatting (`--check`).";
+              default = false;
+            };
           };
         };
       };
@@ -2979,8 +2984,10 @@ in
                 # Searches automatically for the config path.
                 then ""
                 else "-C ${hooks.cmake-format.settings.configPath}";
+              modeFlag =
+                if hooks.cmake-format.settings.inPlace then "--in-place" else "--check";
             in
-            "${hooks.cmake-format.package}/bin/cmake-format --check ${maybeConfigPath}";
+            "${hooks.cmake-format.package}/bin/cmake-format ${modeFlag} ${maybeConfigPath}";
           files = "\\.cmake$|CMakeLists.txt";
         };
       commitizen =

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -315,6 +315,11 @@ in
               default = "";
               example = ".cmake-format.json";
             };
+            inPlace = mkOption {
+              type = types.bool;
+              description = "Format files in place (`-i`) instead of only checking formatting (`--check`).";
+              default = false;
+            };
           };
         };
       };
@@ -3016,8 +3021,10 @@ in
                 # Searches automatically for the config path.
                 then ""
                 else "-C ${hooks.cmake-format.settings.configPath}";
+              modeFlag =
+                if hooks.cmake-format.settings.inPlace then "--in-place" else "--check";
             in
-            "${hooks.cmake-format.package}/bin/cmake-format --check ${maybeConfigPath}";
+            "${hooks.cmake-format.package}/bin/cmake-format ${modeFlag} ${maybeConfigPath}";
           files = "\\.cmake$|CMakeLists.txt";
         };
       commitizen =

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -317,7 +317,7 @@ in
             };
             inPlace = mkOption {
               type = types.bool;
-              description = "Format files in place (`-i`) instead of only checking formatting (`--check`).";
+              description = "Format files in place (`--in-place`) instead of only checking formatting (`--check`).";
               default = false;
             };
           };


### PR DESCRIPTION
This PR:
- Adds an `inPlace` option to `cmake-format` which by default is `false` for backwards compatibility 