### PR TITLE
lychee: use lib.getExe instead of hardcoding binary name

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -3718,7 +3718,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
                   [ (configPath != "") " --config ${configPath}" ]
                 ]);
           in
-          "${hooks.lychee.package}/bin/lychee${cmdArgs} ${hooks.lychee.settings.flags}";
+          "${lib.getExe hooks.lychee.package}${cmdArgs} ${hooks.lychee.settings.flags}";
         types = [ "text" ];
       };
       markdownlint =


### PR DESCRIPTION
`lib.getExe` is useful when users override the `package` option and change its binary name, such as when making a thin wrapper around the original binary.