### PR TITLE
feat: add panche hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ hooks](modules/pre-commit.nix).
 - [mdformat](https://github.com/hukkin/mdformat)
 - [mdl](https://github.com/markdownlint/markdownlint/)
 - [mdsh](https://zimbatm.github.io/mdsh/)
+- [panache](https://github.com/jolars/panache)
 - [rumdl](https://github.com/rvben/rumdl)
 
 ### Nix

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4077,6 +4077,22 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
             in
             "${binPath} ${cmdArgs}";
         };
+      panache-format =
+        {
+          name = "panache-format";
+          description = "Format Quarto, Pandoc, and Markdown files with panache.";
+          package = tools.panache;
+          entry = "${hooks.panache-format.package}/bin/panache format --force-exclude";
+          files = "\\.(qmd|Rmd|md|markdown|mdown|mkd)$";
+        };
+      panache-lint =
+        {
+          name = "panache-lint";
+          description = "Lint Quarto, Pandoc, and Markdown files with panache.";
+          package = tools.panache;
+          entry = "${hooks.panache-lint.package}/bin/panache lint --force-exclude";
+          files = "\\.(qmd|Rmd|md|markdown|mdown|mkd)$";
+        };
       php-cs-fixer =
         {
           name = "php-cs-fixer";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -71,6 +71,7 @@
 , ormolu
 , oxfmt ? placeholder "oxfmt"
 , oxlint
+, panache ? placeholder "panache"
 , pkgsBuildBuild
 , poetry
 , pre-commit-hook-ensure-sops ? placeholder "pre-commit-hook-ensure-sops"
@@ -187,6 +188,7 @@ in
     ormolu
     oxfmt
     oxlint
+    panache
     pre-commit-hook-ensure-sops
     prettier
     poetry


### PR DESCRIPTION
Adds `panache-format` and `panache-lint` hooks for formatting and linting using Panache (<https://panache.bz>), a formatter, linter and language server for markdown, quarto, and r markdown.

Panache is on nixpkgs, but not on the current pin here, so it is safeguarded with a placeholder.