### PR TITLE
statix: pass list settings as repeated flags instead of space-joined string

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4622,12 +4622,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
               };
               options = lib.cli.toCommandLine
                 optionFormat
-                (lib.mapAttrs
-                  (_: v:
-                    if builtins.isList v
-                    then builtins.concatStringsSep " " (lib.unique v)
-                    else v)
-                  settings);
+                settings;
             in
             "${package}/bin/statix check ${toString options}";
           files = "\\.nix$";


### PR DESCRIPTION
This fixes the behaviour of  `statix` hook which, due to the change of the upstream package, now uses `--key value1 --key value2` instead of `--key value1 value2` (see NixOS/nixpkgs#516044 for details).

Disclaimer: I am the maintainer of `statix` in nixpkgs.

This was assisted by OpenCode v1.15.7 as part of personal experiments with it.