### PR TITLE
feat: add hooks.biome.settings.flags for extra CLI flags

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -216,6 +216,13 @@ in
               # underlying biome binary (i.e biome.json if exists)
               default = "";
             };
+
+            flags = mkOption {
+              type = types.str;
+              description = "Additional flags passed to biome. See all available [here](https://biomejs.dev/reference/cli/).";
+              default = "";
+              example = "--no-errors-on-unmatched";
+            };
           };
         };
       };
@@ -2669,6 +2676,7 @@ in
                 mkCmdArgs [
                   [ (hooks.biome.settings.write) "--write" ]
                   [ (hooks.biome.settings.configPath != "") "--config-path ${hooks.biome.settings.configPath}" ]
+                  [ (hooks.biome.settings.flags != "") hooks.biome.settings.flags ]
                 ];
             in
             "${binPath} check ${cmdArgs}";


### PR DESCRIPTION
## Summary

Adds a `flags` option to the biome hook so users can pass arbitrary CLI flags to `biome check`, mirroring the existing `hooks.black.settings.flags` pattern.

## Motivation

The biome hook currently exposes only `binPath`, `write`, and `configPath`. There's no escape hatch for CLI flags that have no `biome.json` equivalent.

The most common need is **`--no-errors-on-unmatched`**: biome exits with code 1 whenever zero files are processed, which happens on commits that touch only files biome excludes (e.g. dep-only commits touching `package.json` + `bun.lock`, or generated-file-only commits). The [official biome git-hooks recipe](https://biomejs.dev/recipes/git-hooks/) recommends this flag specifically. Same friction also blocks #633.

Today users have to override `hooks.biome.entry` via `lib.mkForce`, which is fragile (it duplicates the entire entry string and goes stale when upstream updates the wiring).

## Change

Two additions in `modules/hooks.nix`:

1. `options.settings.flags` on the biome submodule (defaults to empty string).
2. A predicate entry in the `cmdArgs` list builder so the flags are appended to the entry when set.

The pattern is a direct copy of the `hooks.black.settings.flags` option that lives a few lines below in the same file.

## Usage

```nix
git-hooks.hooks.biome = {
  enable = true;
  settings.flags = "--no-errors-on-unmatched";
};
```

## Test plan

- [x] `nix flake check --no-build` passes (validates all module evaluations including the biome submodule's new option).
- [x] Manual review: the predicate `(flags != "")` correctly gates inclusion in `mkCmdArgs`, matching the convention used by the sibling `configPath` predicate.
- [x] Default behavior is unchanged for users not setting `flags` (empty string → no extra arg appended).