### PR TITLE
clippy: add settings.allowedLints

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -283,6 +283,12 @@ in
                 description = "Additional arguments to pass to clippy";
                 default = "";
               };
+              allowedLints = mkOption {
+                type = types.listOf types.str;
+                description = "Lints to allow, passed to clippy as `-A <lint>`";
+                default = [ ];
+                example = [ "clippy::too_many_arguments" ];
+              };
             };
 
             config.extraPackages = [
@@ -2955,7 +2961,7 @@ in
           description = "Lint Rust code.";
           package = wrapper;
           packageOverrides = { cargo = tools.cargo; clippy = tools.clippy; };
-          entry = "${hooks.clippy.package}/bin/cargo-clippy clippy ${cargoManifestPathArg} ${lib.optionalString hooks.clippy.settings.offline "--offline"} ${lib.optionalString hooks.clippy.settings.allFeatures "--all-features"} ${hooks.clippy.settings.extraArgs} -- ${lib.optionalString hooks.clippy.settings.denyWarnings "-D warnings"}";
+          entry = "${hooks.clippy.package}/bin/cargo-clippy clippy ${cargoManifestPathArg} ${lib.optionalString hooks.clippy.settings.offline "--offline"} ${lib.optionalString hooks.clippy.settings.allFeatures "--all-features"} ${hooks.clippy.settings.extraArgs} -- ${lib.optionalString hooks.clippy.settings.denyWarnings "-D warnings"} ${lib.concatMapStringsSep " " (lint: "-A ${lib.escapeShellArg lint}") hooks.clippy.settings.allowedLints}";
           files = "\\.rs$";
           pass_filenames = false;
         };


### PR DESCRIPTION
My project builds with stable cargo 1.96.0, but the clippy hook runs nightly, which knows lints stable doesn't — e.g. `clippy::unused_async_trait_impl`. With `denyWarnings` the hook fails on them, and I can't `#![allow]` the lint in code because stable then complains about an unknown lint.

This adds `settings.allowedLints`, rendered as `-A <lint>` after `-D` warnings so it composes with `denyWarnings`:
```
  hooks.clippy = {
    enable = true;
    settings = {
      denyWarnings = true;
      allowedLints = [ "clippy::unused_async_trait_impl" ];
    };
  };
```

Default is `[]`, so existing configs are unchanged.