### PR TITLE
feat: expose `extendModules` to allow for module overrides

### DIFF
--- a/nix/run.nix
+++ b/nix/run.nix
@@ -32,6 +32,6 @@ let
 
 in
 project.config.run // {
-  inherit (project) config;
+  inherit (project) config extendModules;
   inherit (project.config) enabledPackages shellHook;
 }


### PR DESCRIPTION
This allows us to do something like this:

```nix
rec {
  pre-commit-check = git-hooks.lib.run {
    src = ./.;

    hooks = {
      nixfmt.enable = true;

      # Bash
      shellcheck = {
        enable = true;
        excludes = [ ".envrc" ];
      };
      shfmt.enable = true;
    };
  };

  pre-commit-check-without-shfmt = pre-commit-check.extendModules {
    modules = [({lib, ...} { hooks.shfmt.enable = lib.mkForce false; })]
  };
}
```

I personally use it to switch between which `opentofu` package I use (in the flake `formatter` attribute I need a opentofu package without any nix supplied plugins while I do need them in the flake check because of sandboxing).