### PR TITLE
feat: add google-java-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,10 @@ hooks](modules/pre-commit.nix).
 
 - [html-tidy](https://github.com/htacg/tidy-html5)
 
+### Java
+
+- [google-java-format](https://github.com/google/google-java-format)
+
 ### JavaScript/TypeScript
 
 - [biome](https://biomejs.dev/)

--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -657,6 +657,20 @@ in
           };
         };
       };
+      google-java-format = mkOption {
+        description = "google-java-format hook";
+        type = types.submodule {
+          imports = [ hookModule ];
+          options.settings = {
+            flags = mkOption {
+              type = types.str;
+              description = "Additional flags passed to google-java-format. See all available [here](https://github.com/google/google-java-format/blob/master/README.md#usage).";
+              default = "";
+              example = "--aosp";
+            };
+          };
+        };
+      };
       gotest = mkOption {
         description = "gotest hook";
         type = types.submodule {
@@ -3428,6 +3442,13 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
             builtins.toString script;
           files = "\\.go$";
         };
+      google-java-format = {
+        name = "google-java-format";
+        description = "Reformats Java source code to comply with Google Java Style";
+        package = tools.google-java-format;
+        entry = "${hooks.google-java-format.package}/bin/google-java-format --replace --set-exit-if-changed ${hooks.google-java-format.settings.flags}";
+        files = "\\.java$";
+      };
       gotest = {
         name = "gotest";
         description = "Run go tests";

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -114,6 +114,7 @@
 , go-tools
 , golangci-lint
 , golines
+, google-java-format
 , revive ? placeholder "revive"
 , uv
 , vale
@@ -166,6 +167,7 @@ in
     go-tools
     golangci-lint
     golines
+    google-java-format
     gptcommit
     hadolint
     hledger-fmt


### PR DESCRIPTION
Adds a hook for [google-java-format](https://github.com/google/google-java-format), which is a formatter for Java programming language.