### PR TITLE
inputs: drop gitignore.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,26 +16,6 @@
         "type": "github"
       }
     },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1770073757,
@@ -55,7 +35,6 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,12 +6,8 @@
     url = "github:NixOS/flake-compat";
     flake = false;
   };
-  inputs.gitignore = {
-    url = "github:hercules-ci/gitignore.nix";
-    inputs.nixpkgs.follows = "nixpkgs";
-  };
 
-  outputs = { self, nixpkgs, gitignore, ... }:
+  outputs = { self, nixpkgs, ... }:
     let
       lib = nixpkgs.lib;
       defaultSystems = [
@@ -24,7 +20,7 @@
         let
           args = {
             pkgs = nixpkgs.legacyPackages.${system};
-            exposed = import ./nix { inherit nixpkgs system; gitignore-nix-src = gitignore; isFlakes = true; };
+            exposed = import ./nix { inherit nixpkgs system; isFlakes = true; };
           };
         in
         fn args;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,5 @@
 { system ? builtins.currentSystem
 , nixpkgs
-, gitignore-nix-src
 , isFlakes ? false
 ,
 }:
@@ -15,7 +14,6 @@ let
           pkgs
           tools
           isFlakes
-          gitignore-nix-src
           ;
       };
 

--- a/nix/run.nix
+++ b/nix/run.nix
@@ -1,4 +1,4 @@
-builtinStuff@{ lib, pkgs, tools, gitignore-nix-src, isFlakes }:
+builtinStuff@{ lib, pkgs, tools, isFlakes }:
 
 options@
 { src
@@ -18,12 +18,12 @@ let
             config = lib.mkMerge [
               moduleOptions
               {
-                _module.args = { inherit pkgs gitignore-nix-src; };
+                _module.args = { inherit pkgs; };
                 tools = lib.mkDefault (builtinStuff.tools // tools);
                 rootSrc =
                   if isFlakes
                   then src
-                  else gitignore-nix-src.lib.gitignoreSource src;
+                  else pkgs.nix-gitignore.gitignoreSource [ ] src;
               }
             ];
           }


### PR DESCRIPTION
Replaces `gitignore.nix` with `pkgs.nix-gitignore`, which should behave in the same way and reduce dependencies. Makes it also easier to import `nix/default.nix`.