### PR TITLE
fix: replace 'pre-commit' by `cfg.package.pname`

### DIFF
--- a/modules/pre-commit.nix
+++ b/modules/pre-commit.nix
@@ -103,11 +103,11 @@ let
         git commit -m "init" -q
         if [[ ${toString (compare cfg.installStages [ "manual" ])} -eq 0 ]]
         then
-          echo "Running: $ pre-commit run --hook-stage manual --all-files"
+          echo "Running: $ ${cfg.package.pname} run --hook-stage manual --all-files"
           ${lib.getExe cfg.package} run -c ${cfg.configPath} --hook-stage manual --all-files
         else
-          echo "Running: $ pre-commit run --all-files"
-          ${lib.getExe cfg.package}  run -c ${cfg.configPath} --all-files
+          echo "Running: $ ${cfg.package.pname} run --all-files"
+          ${lib.getExe cfg.package} run -c ${cfg.configPath} --all-files
         fi
         exitcode=$?
         git --no-pager diff --color


### PR DESCRIPTION
As I was recently checking the output of the check, I was confused that it listed `Running: $ pre-commit run --all-files` despite `pre-commit.settings.package = pkgs.prek` being set. This PR resolves the confusion by replacing `'pre-commit'` with `cfg.package.pname`.