### PR TITLE
Add `require_serial = true` to rumdl

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4488,6 +4488,7 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
           package = tools.rumdl;
           entry = "${hooks.rumdl.package}/bin/rumdl check ${cmdArgs}";
           files = "\\.md$";
+          require_serial = true;
         };
       rustfmt =
         let


### PR DESCRIPTION
This produces a single, aggregated output matching the one when running `rumdl check` directly.

Upstream's pre-commit configuration uses this setting as well: https://github.com/rvben/rumdl-pre-commit/commit/890c9f5f537f7110a5ec10ac5f115d4e79fb5a35

Ref https://github.com/rvben/rumdl/issues/350