### PR TITLE
feat(zizmor): match the upstream hook

### DIFF
--- a/modules/hooks.nix
+++ b/modules/hooks.nix
@@ -4996,11 +4996,13 @@ lib.escapeShellArgs (lib.concatMap (ext: [ "--ghc-opt" "-X${ext}" ]) hooks.fourm
         };
       zizmor = {
         name = "zizmor";
-        description = "Static analysis for GitHub Actions";
-        files = "^.github/workflows/";
+        description = "Find security issues in GitHub Actions CI/CD setups";
         types = [ "yaml" ];
+        files = "(\\.github/(workflows/.*|dependabot.ya?ml))|(action\\.ya?ml)$";
+        require_serial = true;
         package = tools.zizmor;
-        entry = "${hooks.zizmor.package}/bin/zizmor";
+        entry = lib.getExe hooks.zizmor.package;
+        args = [ "--no-progress" ]; # https://github.com/zizmorcore/zizmor/issues/582
       };
       zprint =
         {


### PR DESCRIPTION
The zizmor hook has diverged from the upstream hook which -- at the time of writing -- can be found here:
https://github.com/zizmorcore/zizmor-pre-commit/blob/7bb23431317f500c5ab77643e69682c333e875a9/.pre-commit-hooks.yaml

This commit imports the settings from the upstream hook. As a consequence,
- GitHub actions and dependabot configurations are also linted, and
- the progress bar is disabled since it would mess with the output.
